### PR TITLE
Report Share button as a BTN_, instead of KEY_RECORD #20

### DIFF
--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -175,7 +175,7 @@ static int gip_gamepad_init_input(struct gip_gamepad *gamepad)
 
 	gamepad->series_xs = gip_gamepad_is_series_xs(gamepad->client);
 	if (gamepad->series_xs)
-		input_set_capability(dev, EV_KEY, KEY_RECORD);
+		input_set_capability(dev, EV_KEY, BTN_TRIGGER_HAPPY11);
 
 	input_set_capability(dev, EV_KEY, BTN_MODE);
 	input_set_capability(dev, EV_KEY, BTN_START);
@@ -255,7 +255,7 @@ static int gip_gamepad_op_input(struct gip_client *client, void *data, u32 len)
 		if (len < sizeof(*pkt) + sizeof(*pkt_xs))
 			return -EINVAL;
 
-		input_report_key(dev, KEY_RECORD, !!pkt_xs->share_button);
+		input_report_key(dev, BTN_TRIGGER_HAPPY11, !!pkt_xs->share_button);
 	}
 
 	input_report_key(dev, BTN_START, buttons & GIP_GP_BTN_MENU);


### PR DESCRIPTION
Porting over from https://github.com/medusalix/xone/pull/20

On kernel `6.5.5`, can confirm that `evtest` is updated accordingly and under Firefox https://luser.github.io/gamepadtest/ will report the share button as a working 11th button. Though it doesn't seem to work under Edge (flatpak) or Rocket League (proton 8.0).

```
evtest                                                                                                                                                                                      1 ✘  13s  
No device specified, trying to scan all of /dev/input/event*
Not running as root, no devices may be available.
Available devices:
...
/dev/input/event258:    Microsoft Xbox Controller
...
Select the device event number [0-258]: 258

Input driver version is 1.0.1
Input device ID: bus 0x6 vendor 0x45e product 0xb12 version 0x511
Input device name: "Microsoft Xbox Controller"
Supported events:
  Event type 0 (EV_SYN)
  Event type 1 (EV_KEY)
    Event code 304 (BTN_SOUTH)
    Event code 305 (BTN_EAST)
    Event code 307 (BTN_NORTH)
    Event code 308 (BTN_WEST)
    Event code 310 (BTN_TL)
    Event code 311 (BTN_TR)
    Event code 314 (BTN_SELECT)
    Event code 315 (BTN_START)
    Event code 316 (BTN_MODE)
    Event code 317 (BTN_THUMBL)
    Event code 318 (BTN_THUMBR)
    Event code 714 (BTN_TRIGGER_HAPPY11)
  Event type 3 (EV_ABS)
    Event code 0 (ABS_X)
      Value    412
      Min   -32768
      Max    32767
      Fuzz      16
      Flat     128
    Event code 1 (ABS_Y)
      Value    245
      Min   -32768
      Max    32767
      Fuzz      16
      Flat     128
    Event code 2 (ABS_Z)
      Value      0
      Min        0
      Max     1023
    Event code 3 (ABS_RX)
      Value    177
      Min   -32768
      Max    32767
      Fuzz      16
      Flat     128
    Event code 4 (ABS_RY)
      Value   -397
      Min   -32768
      Max    32767
      Fuzz      16
      Flat     128
    Event code 5 (ABS_RZ)
      Value      0
      Min        0
      Max     1023
    Event code 16 (ABS_HAT0X)
      Value      0
      Min       -1
      Max        1
    Event code 17 (ABS_HAT0Y)
      Value      0
      Min       -1
      Max        1
  Event type 21 (EV_FF)
    Event code 80 (FF_RUMBLE)
    Event code 81 (FF_PERIODIC)
    Event code 88 (FF_SQUARE)
    Event code 89 (FF_TRIANGLE)
    Event code 90 (FF_SINE)
    Event code 96 (FF_GAIN)
...
Event: time 1696689585.729637, type 1 (EV_KEY), code 714 (BTN_TRIGGER_HAPPY11), value 1
Event: time 1696689585.729637, -------------- SYN_REPORT ------------
Event: time 1696689585.817695, type 1 (EV_KEY), code 714 (BTN_TRIGGER_HAPPY11), value 0
Event: time 1696689585.817695, -------------- SYN_REPORT ------------
```