### PR TITLE
Fix build error on kernel < 5.15

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -153,11 +153,11 @@ static void gip_bus_remove(struct device *dev)
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
-static int gip_bus_remove_compat(struct device *dev)
+static void gip_bus_remove_compat(struct device *dev)
 {
 	gip_bus_remove(dev);
 
-	return 0;
+	return;
 }
 #endif
 

--- a/bus/bus.c
+++ b/bus/bus.c
@@ -156,8 +156,6 @@ static void gip_bus_remove(struct device *dev)
 static void gip_bus_remove_compat(struct device *dev)
 {
 	gip_bus_remove(dev);
-
-	return;
 }
 #endif
 


### PR DESCRIPTION
Trying to build this on OpenBuildService for packaging for openSUSE, it would fail on LEAP 15.5 builds as the patch [51a7cdc730e7f92760c4451ef6981cda7ae93090](https://github.com/dlundqvist/xone/commit/51a7cdc730e7f92760c4451ef6981cda7ae93090) to fix it on kernels <5.15 actually broke it - it caused a type mismatch - a warning, but it is treated as an error by the build service:

[   24s] /home/abuild/rpmbuild/SOURCES/xone-0.3.2/obj/default/bus/bus.c:169:12: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
[   24s]   .remove = gip_bus_remove_compat,
[   24s]             ^~~~~~~~~~~~~~~~~~~~~

Looking at this, the only immediate difference between the '_compat' version of the function and the main one, was the return value from the new 'compat' function, it's expecting a void and was giving an int, so I changed it, et voila it builds, no more warning/error/failure.

Perhaps this is not the way you'd like to fix this build error, but it works, so feel free to merge it so it can build on systems with older kernels. 