### PR TITLE
Support 5.13 and 5.15

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -152,7 +152,14 @@ static void gip_bus_remove(struct device *dev)
 		drv->remove(client);
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 13, 0)
+static int gip_bus_remove_compat(struct device *dev)
+{
+	gip_bus_remove(dev);
+
+	return 0;
+}
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 static void gip_bus_remove_compat(struct device *dev)
 {
 	gip_bus_remove(dev);


### PR DESCRIPTION
The following error was found by @Levistras

```
(deck@steamdeck xone-v0.3-19-gcc63d27)$ sudo ./install.sh
Driver is already installed!
Installing xone unknown...
Sign command: /usr/lib/modules/5.13.0-valve37-1-neptune/build/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub
Creating symlink /var/lib/dkms/xone/unknown/source -> /usr/src/xone-unknown

Building module:
Cleaning build area...
make -j8 KERNELRELEASE=5.13.0-valve37-1-neptune -C /usr/lib/modules/5.13.0-valve37-1-neptune/build M=/var/lib/dkms/xone/unknown/build...(bad exit status: 2)
Error! Bad return status for module build on kernel: 5.13.0-valve37-1-neptune (x86_64)
Consult /var/lib/dkms/xone/unknown/build/make.log for more information.
DKMS make.log for xone-unknown for kernel 5.13.0-valve37-1-neptune (x86_64)
Thu Nov  2 11:06:08 PM EDT 2023
make: Entering directory '/usr/lib/modules/5.13.0-valve37-1-neptune/build'
  CC [M]  /var/lib/dkms/xone/unknown/build/transport/wired.o
  CC [M]  /var/lib/dkms/xone/unknown/build/transport/dongle.o
  CC [M]  /var/lib/dkms/xone/unknown/build/transport/mt76.o
  CC [M]  /var/lib/dkms/xone/unknown/build/bus/bus.o
  CC [M]  /var/lib/dkms/xone/unknown/build/bus/protocol.o
  CC [M]  /var/lib/dkms/xone/unknown/build/driver/common.o
  CC [M]  /var/lib/dkms/xone/unknown/build/driver/gamepad.o
  CC [M]  /var/lib/dkms/xone/unknown/build/driver/headset.o
/var/lib/dkms/xone/unknown/build/bus/bus.c:167:19: error: initialization of ‘int (*)(struct device *)’ from incompatible pointer type ‘void (*)(struct device *)’ [-Werror=incompatible-pointer-types]
  167 |         .remove = gip_bus_remove_compat,
      |                   ^~~~~~~~~~~~~~~~~~~~~
/var/lib/dkms/xone/unknown/build/bus/bus.c:167:19: note: (near initialization for ‘gip_bus_type.remove’)
cc1: some warnings being treated as errors
make[1]: *** [scripts/Makefile.build:272: /var/lib/dkms/xone/unknown/build/bus/bus.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:1847: /var/lib/dkms/xone/unknown/build] Error 2
make: Leaving directory '/usr/lib/modules/5.13.0-valve37-1-neptune/build'
```

This happens on SteamOS 3.4 (Stable) but not for me on 3.5 (Preview)

Reverting 603688daafe2bff5eb8ca0645964d0f53afbe3ce and 3d34e57e3f47539a7672af00bcd070c4f94c6bd6 allows us both to compile again.