### PR TITLE
fix authentication process for 'under control' xbox controllers (PDP controllers SN-3408-0226)

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -12,7 +12,7 @@
 #define XONE_WIRED_INTF_DATA 0
 #define XONE_WIRED_INTF_AUDIO 1
 
-#define XONE_WIRED_NUM_DATA_URBS 8
+#define XONE_WIRED_NUM_DATA_URBS 12
 #define XONE_WIRED_NUM_AUDIO_URBS 12
 #define XONE_WIRED_NUM_AUDIO_PKTS 8
 
@@ -563,8 +563,6 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x294b) }, /* Snakebyte */
 	{ XONE_WIRED_VENDOR(0x2c16) }, /* Priferential */
 	{ XONE_WIRED_VENDOR(0x0b05) }, /* ASUS */
-	{ XONE_WIRED_VENDOR(0x413d) }, /* BIGBIG WON */
-	{ XONE_WIRED_VENDOR(0x046d) }, /* Logitech Astro */
 	{ },
 };
 


### PR DESCRIPTION
- delays authentication after 1st status message, otherwise my gamepad would stall the auth process when starting input thus never responding as an event device. To fix the issue, the auth process is delayed after receiving the 1st status message from the controller, which was the driver behavior as recorded in windows with usbcap.
- this PR ensures that all auth chunked packets are properly ack'ed as per microsoft specification, otherwise my controller will wait forever for ack to happen (this issue stacks with the previous one).
- added 4 urbs (changed from 8 to 12) to prevent usb urb depletion during auth key echange (seen a couple of times when trying to build this PR)

Note1: this is my third attempt at providing a PR, my two previous attempts were garbage due to my lack of git skill. This one seems fine, no tab/space glitch, not unresolved merge conflicts.
Note2: i tried many other ways to go around my gamepad issue, but this is the only fix that worked. All tree changes are needed to have my gamepad properly register and respond via evdev.
Note3: I tested my PR on a genuine Microsoft XBox controller, and it doesn't seem to break compatibility with this one. I have no other gamepad at hand, so broader regression tests may be needed since the changes are quite significant.