### PR TITLE
Add support for SteelSeries Xbox Headsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Always update your Xbox devices to the latest firmware version!
     - [x] Xbox One Chat Headset
     - [x] Xbox One Stereo Headset (adapter or jack)
     - [x] Xbox Wireless Headset
-    - [x] Third party wireless headsets (SteelSeries, Razer, etc.)
+    - [x] Third party wired and wireless headsets (SteelSeries, Razer, etc.)
 - [x] Guitars & Drums
     - [x] Mad Catz Rock Band 4 Wireless Fender Stratocaster
     - [x] Mad Catz Rock Band 4 Wireless Drum Kit

--- a/transport/wired.c
+++ b/transport/wired.c
@@ -566,6 +566,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x413d) }, /* BIGBIG WON */
 	{ XONE_WIRED_VENDOR(0x046d) }, /* Logitech Astro */
 	{ XONE_WIRED_VENDOR(0x0079) }, /* EasySMX */
+	{ XONE_WIRED_VENDOR(0x1038) }, /* SteelSeries ApS */
 	{ },
 };
 


### PR DESCRIPTION
This PR adds the vendor ID for SteelSeries ApS `0x1038`

My device, the Arctis Nova Pro Wireless, did not work out of the box even with the vendor ID.

The headset.c code assumes that it's safe to call `gip_headset_register` after receiving the first `audio_volume` op, seemingly relying on the fact that `audio_ready` always arrives before it.
In my case the `audio_volume` arrives before `audio_readt` and it results in `gip_init_audio_out` to allocate a 0-byte buffer (`client.audio_config_out` being not yet initialized).

I'm not sure what is the best way to fix this, for now I've added two flags indicating the receipt of `audio_volume` and `audio_ready` and call register only upon receiving both. Feel free to propose a better solution 😉