### PR TITLE
Add support for SteelSeries Xbox Headsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Always update your Xbox devices to the latest firmware version!
     - [x] Xbox One Chat Headset
     - [x] Xbox One Stereo Headset (adapter or jack)
     - [x] Xbox Wireless Headset
-    - [x] Third party wireless headsets (SteelSeries, Razer, etc.)
+    - [x] Third party wired and wireless headsets (SteelSeries, Razer, etc.)
 - [x] Guitars & Drums
     - [x] Mad Catz Rock Band 4 Wireless Fender Stratocaster
     - [x] Mad Catz Rock Band 4 Wireless Drum Kit

--- a/driver/headset.c
+++ b/driver/headset.c
@@ -44,6 +44,8 @@ struct gip_headset {
 	struct delayed_work work_config;
 	struct delayed_work work_power_on;
 	struct work_struct work_register;
+	bool got_ready;
+	bool got_initial_volume;
 	bool registered;
 
 	struct hrtimer timer;
@@ -389,9 +391,27 @@ static int gip_headset_op_authenticate(struct gip_client *client,
 	return gip_auth_process_pkt(&headset->auth, data, len);
 }
 
+static void gip_headset_maybe_register(struct gip_headset *headset)
+{
+	if (!headset->got_ready || !headset->got_initial_volume)
+		return;
+
+	/* ready signal is required as client->audio_config_out is initialized in it */
+	/* and used inside work_register -> gip_init_audio_out */
+	if (!headset->registered) {
+		schedule_work(&headset->work_register);
+		headset->registered = true;
+	}
+}
+
 static int gip_headset_op_audio_ready(struct gip_client *client)
 {
 	struct gip_headset *headset = dev_get_drvdata(&client->dev);
+
+	headset->got_ready = true;
+	/* headset reported supported audio formats */
+	/* (necessary for buffer size calculcations) */
+	gip_headset_maybe_register(headset);
 
 	schedule_delayed_work(&headset->work_power_on, GIP_HS_POWER_ON_DELAY);
 
@@ -403,11 +423,9 @@ static int gip_headset_op_audio_volume(struct gip_client *client,
 {
 	struct gip_headset *headset = dev_get_drvdata(&client->dev);
 
-	/* headset reported initial volume, start audio I/O */
-	if (!headset->registered) {
-		schedule_work(&headset->work_register);
-		headset->registered = true;
-	}
+	/* headset reported initial volume, maybe start audio I/O */
+	headset->got_initial_volume = true;
+	gip_headset_maybe_register(headset);
 
 	/* ignore hardware volume, let software handle volume changes */
 	return 0;

--- a/transport/wired.c
+++ b/transport/wired.c
@@ -563,6 +563,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x294b) }, /* Snakebyte */
 	{ XONE_WIRED_VENDOR(0x2c16) }, /* Priferential */
 	{ XONE_WIRED_VENDOR(0x0b05) }, /* ASUS */
+	{ XONE_WIRED_VENDOR(0x1038) }, /* SteelSeries ApS */
 	{ },
 };
 


### PR DESCRIPTION
This PR adds the vendor ID for SteelSeries ApS 0x1038

My device, the Arctis Nova Pro Wireless, did not work out of the box even with the vendor ID.

The headset.c code assumes that it's safe to call gip_headset_register after receiving the first audio_volume op, seemingly relying on the fact that audio_ready always arrives before it.
In my case the audio_volume arrives before audio_readt and it results in gip_init_audio_out to allocate a 0-byte buffer (client.audio_config_out being not yet initialized).

I'm not sure what is the best way to fix this, for now I've added two flags indicating the receipt of audio_volume and audio_ready and call register only upon receiving both. Feel free to propose a better solution 😉

This is a copy of https://github.com/dlundqvist/xone/pull/25