### PR TITLE
Fix 'encrypt RSA failed' on kernel 6.13

### DIFF
--- a/auth/crypto.c
+++ b/auth/crypto.c
@@ -100,7 +100,7 @@ int gip_auth_encrypt_rsa(u8 *key, int key_len,
 	if (!buf)
 		return -ENOMEM;
 
-	tfm = crypto_alloc_akcipher("pkcs1pad(rsa,sha256)", 0, 0);
+	tfm = crypto_alloc_akcipher("pkcs1pad(rsa)", 0, 0);
 	if (IS_ERR(tfm)) {
 		err = PTR_ERR(tfm);
 		goto err_free_buf;


### PR DESCRIPTION
Implemented NixieQueen's fix as seen in issue #33

I have been testing this on my third-party xone controller for a couple days, and all seems well