### PR TITLE
Allow build on clang kernels - e.g., OpenMandriva

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,6 @@
 PACKAGE_NAME="xone"
 PACKAGE_VERSION="#VERSION#"
+MAKE[0]="make V=1 LLVM=1 -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 BUILT_MODULE_NAME[0]="xone-wired"
 BUILT_MODULE_NAME[1]="xone-dongle"
 BUILT_MODULE_NAME[2]="xone-gip"

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,14 @@ echo "Installing xone $version..."
 cp -r . "$source"
 find "$source" -type f \( -name dkms.conf -o -name '*.c' \) -exec sed -i "s/#VERSION#/$version/" {} +
 
+# The MAKE line in dkms.conf is required for kernels built using clang. Remove
+# it if the kernel is built using gcc - i.e. "clang" is not in the kernel
+# version string.
+
+if [ -z "$(cat /proc/version | grep clang)" ]; then
+    find "$source" -type f \( -name dkms.conf -o -name '*.c' \) -exec sed -i "/^MAKE/d" {} +
+fi
+
 if [ "${1:-}" != --release ]; then
     echo 'ccflags-y += -DDEBUG' >> "$source/Kbuild"
 fi


### PR DESCRIPTION
Kernels built using clang - e.g., OpenMandriva - require LLVM=1 as part of the make command to build and install.