### PR TITLE
Fix: Only send audio, after device is authorised. Fixes #27 `Headset Razer Kaira Pro can't complete handshake most of the time`

### DIFF
--- a/auth/auth.c
+++ b/auth/auth.c
@@ -536,6 +536,8 @@ static void gip_auth_complete_handshake(struct work_struct *work)
 	if (err)
 		dev_err(&auth->client->dev,
 			"%s: set encryption key failed: %d\n", __func__, err);
+
+    auth->client->auth_complete = true;
 }
 
 static int gip_auth_dispatch_pkt(struct gip_auth *auth,

--- a/bus/bus.h
+++ b/bus/bus.h
@@ -63,6 +63,8 @@ struct gip_client {
 	struct device dev;
 	u8 id;
 
+    u8 auth_complete;
+
 	struct gip_adapter *adapter;
 	struct gip_driver *drv;
 	struct semaphore drv_lock;


### PR DESCRIPTION
Heyy,
I also haven an Razer Kaira Pro and found a solution.
Microsoft states:

> The device SHOULD also not wait for security to complete before the volume indication and captured audio are  sent. Note that any volume changes made to the device or audio sent to the host during the security handshake are processed in parallel. (in _2.2.11 Audio Initialization_)

which Razer has totally ignored, resulting in being unable to negotiate a handshake while already receiving audio.

My solution is to just drop any audio packets which the driver wants to send until the handshake is complete.