### PR TITLE
Fix building on 6.15

### DIFF
--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -6,6 +6,7 @@
 #include <linux/module.h>
 #include <linux/uuid.h>
 #include <linux/timer.h>
+#include <linux/version.h>
 
 #include "common.h"
 #include "../auth/auth.h"
@@ -207,8 +208,11 @@ static int gip_gamepad_init_input(struct gip_gamepad *gamepad)
 	return 0;
 
 err_delete_timer:
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
+	timer_delete_sync(&gamepad->rumble.timer);
+#else
 	del_timer_sync(&gamepad->rumble.timer);
-
+#endif
 	return err;
 }
 
@@ -335,7 +339,11 @@ static void gip_gamepad_remove(struct gip_client *client)
 {
 	struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
+	timer_delete_sync(&gamepad->rumble.timer);
+#else
 	del_timer_sync(&gamepad->rumble.timer);
+#endif
 }
 
 static struct gip_driver gip_gamepad_driver = {

--- a/driver/headset.c
+++ b/driver/headset.c
@@ -6,6 +6,7 @@
 #include <linux/module.h>
 #include <linux/hrtimer.h>
 #include <linux/vmalloc.h>
+#include <linux/version.h>
 #include <sound/core.h>
 #include <sound/initval.h>
 #include <sound/pcm.h>
@@ -499,8 +500,13 @@ static int gip_headset_probe(struct gip_client *client)
 	INIT_DELAYED_WORK(&headset->work_power_on, gip_headset_power_on);
 	INIT_WORK(&headset->work_register, gip_headset_register);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
+	hrtimer_setup(&headset->timer, gip_headset_send_samples,
+		      CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+#else
 	hrtimer_init(&headset->timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
 	headset->timer.function = gip_headset_send_samples;
+#endif
 
 	err = gip_enable_audio(client);
 	if (err)


### PR DESCRIPTION
6.15 introduces breaking changes in timers: https://lkml.org/lkml/2025/4/6/101

After fix (no errors on 6.15 and previous versions):
```
(2/3) Install DKMS modules
==> dkms install --no-depmod xone/0.3.3 -k 6.14.1-arch1-1
==> dkms install --no-depmod xone/0.3.3 -k 6.12.22-1-lts
==> dkms install --no-depmod xone/0.3.3 -k 6.15.0-rc1-00060-ga24588245776
==> depmod 6.12.22-1-lts
==> depmod 6.15.0-rc1-00060-ga24588245776
==> depmod 6.14.1-arch1-1
```

Fixes #44 