### PR TITLE
wireless controllers kept alive on reboot

### DIFF
--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -1091,6 +1091,9 @@ static void xone_dongle_shutdown(struct device *dev)
 	struct xone_dongle *dongle = usb_get_intfdata(intf);
 	int err;
 
+	if (system_state == SYSTEM_RESTART)
+		return;
+
 	err = xone_dongle_power_off_clients(dongle);
 	if (err)
 		dev_err(dongle->mt.dev, "%s: power off failed: %d\n",


### PR DESCRIPTION
Stops the wireless controllers from turning off during reboot. They will still turn off for shutdown, sleep, hibernate etc.  Very helpful and removes the step of having to turn the controllers back on if you need to reboot the system for some reason.