### PR TITLE
Fix: update gip_bus_match() signature for kernel 6.11+ compatibility

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -58,9 +58,6 @@ static struct device_type gip_client_type = {
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int gip_bus_match(struct device *dev, struct device_driver *driver)
-#else
-static int gip_bus_match(struct device *dev, const struct device_driver *driver)
-#endif
 {
 	struct gip_client *client;
 	struct gip_driver *drv;
@@ -78,6 +75,27 @@ static int gip_bus_match(struct device *dev, const struct device_driver *driver)
 
 	return false;
 }
+#else
+static int gip_bus_match(struct device *dev, const struct device_driver *driver)
+{
+	struct gip_client *client;
+	struct gip_driver *gip_drv;
+	int i;
+
+	if (dev->type != &gip_client_type)
+		return false;
+
+	client = to_gip_client(dev);
+	gip_drv = to_gip_driver(driver);
+
+	for (i = 0; i < client->classes->count; i++)
+		if (!strcmp(client->classes->strings[i], gip_drv->class))
+			return true;
+
+	return false;
+}
+#endif
+
 
 static int gip_bus_probe(struct device *dev)
 {


### PR DESCRIPTION
## Summary

Kernel 6.11 introduced a breaking change to the `match` function signature in `struct bus_type`, updating the second parameter to use `const`:

```c
int (*match)(struct device *, const struct device_driver *)
```

This caused a build failure for xone on newer kernels:

```c
error: initialization of ‘int (*)(struct device *, const struct device_driver *)’ 
from incompatible pointer type
```

Fix
This patch updates the gip_bus_match() function to use the correct signature on kernel 6.11 and above, while maintaining compatibility with older kernels by using #if LINUX_VERSION_CODE guards.

## Testing
Confirmed to build and install correctly on:

- Ubuntu 24.04
