### PR TITLE
Elite 2 paddle support (multiple firmware versions)

### DIFF
--- a/bus/bus.h
+++ b/bus/bus.h
@@ -98,7 +98,7 @@ struct gip_driver_ops {
 	int (*audio_volume)(struct gip_client *client, u8 in, u8 out);
 	int (*hid_report)(struct gip_client *client, void *data, u32 len);
 	int (*input)(struct gip_client *client, void *data, u32 len);
-    int (*firmware)(struct gip_client *client, void *data, u32 len);
+	int (*firmware)(struct gip_client *client, void *data, u32 len);
 	int (*audio_samples)(struct gip_client *client, void *data, u32 len);
 };
 

--- a/bus/bus.h
+++ b/bus/bus.h
@@ -98,6 +98,7 @@ struct gip_driver_ops {
 	int (*audio_volume)(struct gip_client *client, u8 in, u8 out);
 	int (*hid_report)(struct gip_client *client, void *data, u32 len);
 	int (*input)(struct gip_client *client, void *data, u32 len);
+    int (*firmware)(struct gip_client *client, void *data, u32 len);
 	int (*audio_samples)(struct gip_client *client, void *data, u32 len);
 };
 

--- a/bus/protocol.c
+++ b/bus/protocol.c
@@ -709,6 +709,21 @@ int gip_init_audio_out(struct gip_client *client)
 }
 EXPORT_SYMBOL_GPL(gip_init_audio_out);
 
+int gip_init_extra_data(struct gip_client *client)
+{
+struct gip_header hdr = {};
+
+	hdr.command = 0x4d; // ???
+	hdr.options |= GIP_OPT_ACKNOWLEDGE; // Because 4
+	hdr.sequence = 1;
+	hdr.packet_length = 2;
+
+	u8 packet_data[] = {0x07, 0x00};
+
+	return gip_send_pkt(client, &hdr, &packet_data);
+}
+EXPORT_SYMBOL_GPL(gip_init_extra_data);
+
 void gip_disable_audio(struct gip_client *client)
 {
 	struct gip_adapter *adap = client->adapter;

--- a/bus/protocol.c
+++ b/bus/protocol.c
@@ -711,7 +711,7 @@ EXPORT_SYMBOL_GPL(gip_init_audio_out);
 
 int gip_init_extra_data(struct gip_client *client)
 {
-struct gip_header hdr = {};
+	struct gip_header hdr = {};
 
 	hdr.command = 0x4d; // ???
 	hdr.options |= GIP_OPT_ACKNOWLEDGE; // Because 4
@@ -1474,8 +1474,6 @@ static int gip_dispatch_pkt(struct gip_client *client,
 			return gip_handle_pkt_hid_report(client, data, len);
 		case GIP_CMD_AUDIO_SAMPLES:
 			return gip_handle_pkt_audio_samples(client, data, len);
-        case GIP_CMD_FIRMWARE:
-            return gip_handle_pkt_firmware(client, data, len);
 		default:
 			return 0;
 		}
@@ -1484,6 +1482,8 @@ static int gip_dispatch_pkt(struct gip_client *client,
 	switch (hdr->command) {
 	case GIP_CMD_INPUT:
 		return gip_handle_pkt_input(client, data, len);
+	case GIP_CMD_FIRMWARE:
+		return gip_handle_pkt_firmware(client, data, len);
 	}
 
 	return 0;

--- a/bus/protocol.c
+++ b/bus/protocol.c
@@ -408,7 +408,7 @@ static int gip_acknowledge_pkt(struct gip_client *client,
 
 	if ((ack->options & GIP_OPT_CHUNK) && buf)
 		pkt.remaining = cpu_to_le16(buf->length - len);
-	
+
 	gip_dbg(client, "%s: ACME command=0x%02x, length=0x%04x\n",
 		__func__, pkt.command, len);
 
@@ -711,14 +711,13 @@ EXPORT_SYMBOL_GPL(gip_init_audio_out);
 
 int gip_init_extra_data(struct gip_client *client)
 {
-	struct gip_header hdr = {};
-
-	hdr.command = 0x4d; // ???
-	hdr.options |= GIP_OPT_ACKNOWLEDGE; // Because 4
-	hdr.sequence = 1;
-	hdr.packet_length = 2;
-
-	u8 packet_data[] = {0x07, 0x00};
+	struct gip_header hdr = {
+		.command = 0x4d, // ???
+		.options = GIP_OPT_ACKNOWLEDGE, // Because 4
+		.sequence = 1,
+		.packet_length = 2,
+	};
+	u8 packet_data[] = { 0x07, 0x00 };
 
 	return gip_send_pkt(client, &hdr, &packet_data);
 }
@@ -1435,20 +1434,20 @@ static int gip_handle_pkt_audio_samples(struct gip_client *client,
 	return err;
 }
 
-static int gip_handle_pkt_firmware(struct gip_client *client,
-                void *data, u32 len)
+static int gip_handle_pkt_firmware(struct gip_client *client, void *data,
+				   u32 len)
 {
-    int err = 0;
+	int err;
 
-    if (down_trylock(&client->drv_lock))
-        return -EBUSY;
+	if (down_trylock(&client->drv_lock))
+		return -EBUSY;
 
-    if (client->drv && client->drv->ops.firmware)
-        err = client->drv->ops.firmware(client, data, len);
+	if (client->drv && client->drv->ops.firmware)
+		err = client->drv->ops.firmware(client, data, len);
 
-    up(&client->drv_lock);
+	up(&client->drv_lock);
 
-    return err;
+	return err;
 }
 
 static int gip_dispatch_pkt(struct gip_client *client,
@@ -1484,6 +1483,8 @@ static int gip_dispatch_pkt(struct gip_client *client,
 		return gip_handle_pkt_input(client, data, len);
 	case GIP_CMD_FIRMWARE:
 		return gip_handle_pkt_firmware(client, data, len);
+	default:
+		pr_debug("%s: Unknown hdr command", __func__);
 	}
 
 	return 0;
@@ -1525,7 +1526,7 @@ static int gip_process_pkt_chunked(struct gip_client *client,
 
 	if (hdr->packet_length) {
 		/*
-		 * acknowledge last non-empty chunked packet even when 
+		 * acknowledge last non-empty chunked packet even when
 		 * not asked in current chunk header
 		 */
 		bool last_chunk = (buf->length == len);

--- a/bus/protocol.h
+++ b/bus/protocol.h
@@ -110,6 +110,7 @@ int gip_send_rumble(struct gip_client *client, void *pkt, u32 len);
 int gip_set_led_mode(struct gip_client *client,
 		     enum gip_led_mode mode, u8 brightness);
 int gip_send_audio_samples(struct gip_client *client, void *samples);
+int gip_init_extra_data(struct gip_client *client);
 
 bool gip_has_interface(struct gip_client *client, const guid_t *guid);
 int gip_set_encryption_key(struct gip_client *client, u8 *key, int len);

--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -19,13 +19,16 @@
 // Various versions of the Elite Series 2 firmware have changed the way paddle
 // states are sent. Paddle support is only reported up to this firmware
 // version.
-#define GIP_ELITE_SERIES_2_MAX_FIRMWARE 0x04FF
+#define GIP_ELITE_SERIES_2_4X_FIRMWARE 0x04FF
+#define GIP_ELITE_SERIES_2_510_FIRMWARE 0x050A
 
 #define GIP_GP_RUMBLE_DELAY msecs_to_jiffies(10)
 #define GIP_GP_RUMBLE_MAX 100
 
 /* button offset from end of packet */
 #define GIP_GP_BTN_SHARE_OFFSET 18
+
+#define gip_dbg(client, ...) dev_dbg(&(client)->adapter->dev, __VA_ARGS__)
 
 static const guid_t gip_gamepad_guid_share =
 	GUID_INIT(0xecddd2fe, 0xd387, 0x4294,
@@ -66,6 +69,15 @@ enum gip_gamepad_motor {
 	GIP_GP_MOTOR_LT = BIT(3),
 };
 
+struct gip_gamepad_pkt_firmware {
+    // Remember, xpad keeps the 4 bytes.
+    // Paddles are at [18] in xpad, so, [14] here.
+    // Pad 13 bytes.
+    u8 unknown[13];
+    u8 paddles;
+    u8 profile;
+} __packed;
+
 struct gip_gamepad_pkt_input {
 	__le16 buttons;
 	__le16 trigger_left;
@@ -96,8 +108,9 @@ struct gip_gamepad_pkt_rumble {
 typedef enum {
 	PADDLE_NONE,
 	PADDLE_ELITE,
-	PADDLE_ELITE2_OLDFW,
-	PADDLE_ELITE2 //Not yet implemented, need a tester
+	PADDLE_ELITE2_4X, // Still in the same packet
+	PADDLE_ELITE2_510, // Same packet, different location
+    PADDLE_ELITE2_511 // Different packet entirely.
 } PaddleCapability;
 
 struct gip_gamepad {
@@ -204,15 +217,21 @@ static int gip_gamepad_init_input(struct gip_gamepad *gamepad)
 		if(hardware.product == GIP_PRODUCT_ELITE) {
 			gamepad->paddle_support = PADDLE_ELITE;
 		}
-		else if(hardware.product == GIP_PRODUCT_ELITE_SERIES_2 && hardware.version <= GIP_ELITE_SERIES_2_MAX_FIRMWARE) {
-			gamepad->paddle_support = PADDLE_ELITE2_OLDFW;
-		}
+        else if (hardware.product == GIP_PRODUCT_ELITE_SERIES_2)
+        {
+            if (hardware.version <= GIP_ELITE_SERIES_2_4X_FIRMWARE)
+                gamepad->paddle_support = PADDLE_ELITE2_4X;
+            else if (hardware.version <= GIP_ELITE_SERIES_2_510_FIRMWARE)
+                gamepad->paddle_support = PADDLE_ELITE2_510;
+            else if (hardware.version > GIP_ELITE_SERIES_2_510_FIRMWARE) // If new revisions come, this should become LTE new max
+                gamepad->paddle_support = PADDLE_ELITE2_511;
+        }
 	}
 
 	if (gamepad->supports_share)
 		input_set_capability(dev, EV_KEY, KEY_RECORD);
 
-	if ((gamepad->paddle_support ==  PADDLE_ELITE) || (gamepad->paddle_support == PADDLE_ELITE2_OLDFW)) {
+	if ((gamepad->paddle_support ==  PADDLE_ELITE) || (gamepad->paddle_support == PADDLE_ELITE2_4X) || (gamepad->paddle_support == PADDLE_ELITE2_510) || (gamepad->paddle_support == PADDLE_ELITE2_511)) {
 		input_set_capability(dev, EV_KEY, BTN_TRIGGER_HAPPY5);
 		input_set_capability(dev, EV_KEY, BTN_TRIGGER_HAPPY6);
 		input_set_capability(dev, EV_KEY, BTN_TRIGGER_HAPPY7);
@@ -299,6 +318,34 @@ static int gip_gamepad_op_authenticated(struct gip_client *client)
 	return gip_gamepad_init_input(gamepad);
 }
 
+static int gip_gamepad_op_firmware(struct gip_client *client, void *data, u32 len)
+{
+    // First, ensure the data is of the correct size.
+    // This will probably footgun us later.
+    struct gip_gamepad_pkt_firmware *pkt = data;
+    if (len < sizeof (*pkt))
+        return -EINVAL;
+
+    // Grab our controller
+    struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
+    struct input_dev *dev = gamepad->input.dev;
+
+    // mimic xpad behavior of ignoring if a profile is set
+    // if (pkt->profile == 0 )
+	// {
+	input_report_key(dev, BTN_TRIGGER_HAPPY5, pkt->paddles & GIP_GP_BTN_P1);
+	input_report_key(dev, BTN_TRIGGER_HAPPY6, pkt->paddles & GIP_GP_BTN_P2);
+	input_report_key(dev, BTN_TRIGGER_HAPPY7, pkt->paddles & GIP_GP_BTN_P3);
+	input_report_key(dev, BTN_TRIGGER_HAPPY8, pkt->paddles & GIP_GP_BTN_P4);
+    // }
+
+	gip_dbg(client, "%s: paddles: %d profile:", __func__, pkt->paddles, pkt->profile);
+
+    input_sync(dev);
+
+    return 0;
+}
+
 static int gip_gamepad_op_input(struct gip_client *client, void *data, u32 len)
 {
 	struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
@@ -336,10 +383,29 @@ static int gip_gamepad_op_input(struct gip_client *client, void *data, u32 len)
 	input_report_key(dev, BTN_THUMBR, buttons & GIP_GP_BTN_STICK_R);
 
 
-	//For anyone comparing to xpad's paddle handling source, xone strips four bytes of header off of the beginning that xpad doesn't, so all offsets are 4 less
-	if ((gamepad->paddle_support == PADDLE_ELITE2_OLDFW) && (len > 14)) {
-		// On the Elite Series 2 with older firmware paddles are stored at byte 14
+	// For anyone comparing to xpad's paddle handling source,
+    // xone strips four bytes of header off of the beginning that xpad doesn't, so all offsets are 4 less
+    // later revisions put paddle support in the firmware packet, check gip_gamepad_op_WTFEVER
+    if ((gamepad->paddle_support == PADDLE_ELITE2_510) && (len > 18)) { // Assume the controller might not send profile data.
+        // On the Elite Series 2 with newer-ISH firmware (<=5.10) paddles are stored at byte 18 (22)
+        u8 paddles = ((u8 *) data)[18];
+
+        // But first, ensure a profile is not applied, like xpad.
+        if ((len > 19) && ((u8 *) data)[19] != 0)
+            paddles = 0;
+
+        input_report_key(dev, BTN_TRIGGER_HAPPY5, paddles & GIP_GP_BTN_P1);
+        input_report_key(dev, BTN_TRIGGER_HAPPY6, paddles & GIP_GP_BTN_P2);
+        input_report_key(dev, BTN_TRIGGER_HAPPY7, paddles & GIP_GP_BTN_P3);
+        input_report_key(dev, BTN_TRIGGER_HAPPY8, paddles & GIP_GP_BTN_P4);
+    } else if ((gamepad->paddle_support == PADDLE_ELITE2_4X) && (len > 14)) {
+		// On the Elite Series 2 with older firmware (<5.11) paddles are stored at byte 14 (18)
 		u8 paddles = ((u8 *) data)[14];
+
+        // But first, ensure a profile is not applied, like xpad.
+        if ((len > 15) && ((u8 *) data)[15] != 0)
+            paddles = 0;
+
 		input_report_key(dev, BTN_TRIGGER_HAPPY5, paddles & GIP_GP_BTN_P1);
 		input_report_key(dev, BTN_TRIGGER_HAPPY6, paddles & GIP_GP_BTN_P2);
 		input_report_key(dev, BTN_TRIGGER_HAPPY7, paddles & GIP_GP_BTN_P3);
@@ -424,6 +490,7 @@ static struct gip_driver gip_gamepad_driver = {
 		.authenticated = gip_gamepad_op_authenticated,
 		.guide_button = gip_gamepad_op_guide_button,
 		.input = gip_gamepad_op_input,
+        .firmware = gip_gamepad_op_firmware,
 	},
 	.probe = gip_gamepad_probe,
 	.remove = gip_gamepad_remove,

--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -201,6 +201,11 @@ static int gip_gamepad_init_rumble(struct gip_gamepad *gamepad)
 	return input_ff_create_memless(dev, NULL, gip_gamepad_queue_rumble);
 }
 
+static int gip_gamepad_init_extra_data(struct gip_gamepad *gamepad)
+{
+	return gip_init_extra_data(gamepad->client);
+}
+
 static int gip_gamepad_init_input(struct gip_gamepad *gamepad)
 {
 	struct input_dev *dev = gamepad->input.dev;
@@ -339,7 +344,7 @@ static int gip_gamepad_op_firmware(struct gip_client *client, void *data, u32 le
 	input_report_key(dev, BTN_TRIGGER_HAPPY8, pkt->paddles & GIP_GP_BTN_P4);
     // }
 
-	gip_dbg(client, "%s: paddles: %d profile:", __func__, pkt->paddles, pkt->profile);
+	gip_dbg(client, "%s: paddles: %d profile: %d", __func__, pkt->paddles, pkt->profile);
 
     input_sync(dev);
 
@@ -462,6 +467,14 @@ static int gip_gamepad_probe(struct gip_client *client)
 		return err;
 
 	err = gip_init_input(&gamepad->input, client, GIP_GP_NAME);
+	if (err)
+		return err;
+
+	err = gip_gamepad_init_input(gamepad);
+	if (err)
+		return err;
+
+	err = gip_gamepad_init_extra_data(gamepad);
 	if (err)
 		return err;
 


### PR DESCRIPTION
This is based on https://github.com/medusalix/xone/pull/41 but fixes a bunch of known issues described in the discussion of that pull request:

Removes blacklisting of Xbox controllers with profiles (improperly inspired by xpad) supported.  Elite profiles support a vast variety of functionality beyond merely remapping paddles, and blacklisting paddles because someone altered their stick mapping or button brightness is braindead behavior.
Adds support for recent Elite 2 firmware versions.  As a result multiple FW versions are supported.  The latest seems to be fairly stable as it has not changed in a while, but support for older firmware versions should be retained for those who do not have access to an Xbox machine or a Windows machine, unless someone can provide an example of a way to update Xbox Elite 2 firmware from Linux without running a Windows VM.

The original patch series against upstream has been tested by myself for over a year, and so far applies cleanly/works OK when applied against this fork.

So far i have not squashed any commits.  After review, I plan to squash commits that do not cross authorship boundaries as authorship should be preserved for the three different contributors to this PR.