### PR TITLE
Fix snprintf call warning/error

### DIFF
--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -887,15 +887,12 @@ static int xone_dongle_init(struct xone_dongle *dongle,
 	dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
 			__func__, fwname);
 	err = request_firmware(&fw, fwname, mt->dev);
-	if (err) {
-		if (err == -ENOENT) {
-			snprintf(fwname, 25, "xow_dongle.bin",
-				 id->idVendor, id->idProduct);
-			dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
-				__func__, fwname);
-			err = request_firmware(&fw, fwname, mt->dev);
-
-		}
+	if (err == -ENOENT) {
+		snprintf(fwname, 25, "xow_dongle.bin",
+				id->idVendor, id->idProduct);
+		dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
+			__func__, fwname);
+		err = request_firmware(&fw, fwname, mt->dev);
 	}
 
 	if (err) {

--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -888,8 +888,7 @@ static int xone_dongle_init(struct xone_dongle *dongle,
 			__func__, fwname);
 	err = request_firmware(&fw, fwname, mt->dev);
 	if (err == -ENOENT) {
-		snprintf(fwname, 25, "xow_dongle.bin",
-				id->idVendor, id->idProduct);
+		snprintf(fwname, 15, "xow_dongle.bin");
 		dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
 			__func__, fwname);
 		err = request_firmware(&fw, fwname, mt->dev);


### PR DESCRIPTION
```
transport/dongle.c: In function ‘xone_dongle_init’:
transport/dongle.c:892:46: warning: too many arguments for format [-Wformat-extra-args]
  892 |                         snprintf(fwname, 25, "xow_dongle.bin",
      |                                              ^~~~~~~~~~~~~~~~
```

Fixes #63 