### PR TITLE
Skip loading "exact firmware" for the official dongle

### DIFF
--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -882,12 +882,23 @@ static int xone_dongle_init(struct xone_dongle *dongle,
 	if (err)
 		return err;
 
-	snprintf(fwname, 25, "xow_dongle_%04x_%04x.bin",
-		 id->idVendor, id->idProduct);
-	dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
+	/*
+	 * Skip loading "exact" firmware if the official
+	 * Microsoft dongle has been detected
+	 */
+	bool official_dongle =
+		(id->idVendor == 0x045e && id->idProduct == 0x02fe);
+
+	err = 0;
+	if (!official_dongle) {
+		snprintf(fwname, 25, "xow_dongle_%04x_%04x.bin",
+			 id->idVendor, id->idProduct);
+		dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
 			__func__, fwname);
-	err = request_firmware(&fw, fwname, mt->dev);
-	if (err == -ENOENT) {
+		err = request_firmware(&fw, fwname, mt->dev);
+	}
+
+	if (err == -ENOENT || official_dongle) {
 		snprintf(fwname, 15, "xow_dongle.bin");
 		dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
 			__func__, fwname);


### PR DESCRIPTION
Fixes #65 

Might help with #61 

dmesg after fix:
```
usb 3-4.1.2: new high-speed USB device number 14 using xhci_hcd
usb 3-4.1.2: New USB device found, idVendor=045e, idProduct=02fe, bcdDevice= 1.00
usb 3-4.1.2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
usb 3-4.1.2: Product: XBOX ACC
usb 3-4.1.2: Manufacturer: Microsoft Inc.
usb 3-4.1.2: SerialNumber: 050305
xone_gip: loading out-of-tree module taints kernel.
xone_gip: module verification failed: signature and/or required key missing - tainting kernel
usb 3-4.1.2: reset high-speed USB device number 14 using xhci_hcd
usbcore: registered new interface driver xone-dongle
```

Before the fix, there was an error in there:
```
xone-dongle 3-4.1.2:1.0: Direct firmware load for xow_dongle_045e_02fe.bin failed with error -2
```