### PR TITLE
Remove installation of firmware fetch script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,6 @@ fi
 if dkms install -m xone -v "$version"; then
     # The blacklist should be placed in /usr/local/lib/modprobe.d for kmod 29+
     install -D -m 644 install/modprobe.conf /etc/modprobe.d/xone-blacklist.conf
-    install -D -m 755 install/firmware.sh /usr/local/bin/xone-get-firmware.sh
 
     # Avoid conflicts between xpad and xone
     if lsmod | grep -q '^xpad'; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -21,6 +21,7 @@ if [ -n "$version" ]; then
     dkms remove -m xone -v "$version" --all
     rm -r "/usr/src/xone-$version"
     rm -f /etc/modprobe.d/xone-blacklist.conf
+    # TODO: Remove later
     rm -f /usr/local/bin/xone-get-firmware.sh
 else
     echo 'Driver is not installed!' >&2


### PR DESCRIPTION
Because of #67, the setup scripts should also follow suit and not install `/usr/local/bin/xone-get-firmware.sh`. For now however, let the file be naturally deleted for existing users that are still syncing with repo updates.