### PR TITLE
Fix: Unable to sync LS35X Headset with Dongle

### DIFF
--- a/driver/headset.c
+++ b/driver/headset.c
@@ -22,7 +22,7 @@
 #define GIP_HS_PID_CHAT 0x0111
 
 #define GIP_HS_MAX_RETRIES 6
-#define GIP_HS_POWER_ON_DELAY msecs_to_jiffies(250)
+#define GIP_HS_POWER_ON_DELAY msecs_to_jiffies(1000)
 #define GIP_HS_START_DELAY msecs_to_jiffies(500)
 
 static struct gip_vidpid GIP_HS_CHECK_AUTH_IDS[] = {
@@ -323,6 +323,10 @@ static enum hrtimer_restart gip_headset_start_audio(struct hrtimer *timer)
 	if (err)
 		dev_err(&headset->client->dev,
 			"%s: set power mode failed: %d\n", __func__, err);
+	err = gip_set_led_mode(headset->client, GIP_LED_OFF, 0);
+	if (err)
+		dev_err(&headset->client->dev,
+			"%s: set led mode failed: %d\n", __func__, err);
 	hrtimer_forward_now(timer, ms_to_ktime(GIP_HS_START_DELAY));
 
 	return HRTIMER_RESTART;


### PR DESCRIPTION
This PR aims at solving the issue described in issue https://github.com/dlundqvist/xone/issues/42.

Current phase consists in adding traces to figure out why the devices disconnects from the host about 1sec after audio config.

Trace headset.c async init messages

fixes https://github.com/dlundqvist/xone/issues/76