### PR TITLE
Add Makefile and instructions how to use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 internal/*
 .vscode/*
+*.o
+*.cmd
+*.order
+*.symvers
+*.ko
+*.mod
+*.mod.c

--- a/Kbuild
+++ b/Kbuild
@@ -1,10 +1,19 @@
-xone-wired-y := transport/wired.o
-xone-dongle-y := transport/dongle.o transport/mt76.o
-xone-gip-y := bus/bus.o bus/protocol.o auth/auth.o auth/crypto.o driver/common.o
-xone-gip-gamepad-y := driver/gamepad.o
-xone-gip-headset-y := driver/headset.o
-xone-gip-chatpad-y := driver/chatpad.o
-xone-gip-madcatz-strat-y := driver/madcatz_strat.o
-xone-gip-madcatz-glam-y := driver/madcatz_glam.o
-xone-gip-pdp-jaguar-y := driver/pdp_jaguar.o
-obj-m := xone-wired.o xone-dongle.o xone-gip.o xone-gip-gamepad.o xone-gip-headset.o xone-gip-chatpad.o xone-gip-madcatz-strat.o xone-gip-madcatz-glam.o xone-gip-pdp-jaguar.o
+xone_gip-y := bus/bus.o bus/protocol.o auth/auth.o auth/crypto.o driver/common.o
+xone_wired-y := transport/wired.o
+xone_dongle-y := transport/dongle.o transport/mt76.o
+xone_gip_gamepad-y := driver/gamepad.o
+xone_gip_headset-y := driver/headset.o
+xone_gip_chatpad-y := driver/chatpad.o
+xone_gip_madcatz_strat-y := driver/madcatz_strat.o
+xone_gip_madcatz_glam-y := driver/madcatz_glam.o
+xone_gip_pdp_jaguar-y := driver/pdp_jaguar.o
+
+obj-m := xone_gip.o \
+	xone_wired.o \
+	xone_dongle.o \
+	xone_gip_gamepad.o \
+	xone_gip_headset.o \
+	xone_gip_chatpad.o \
+	xone_gip_madcatz_strat.o \
+	xone_gip_madcatz_glam.o \
+	xone_gip_pdp_jaguar.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+KVERSION := $(shell uname -r)
+KDIR := /lib/modules/${KVERSION}/build
+MAKEFLAGS+="-j $(shell nproc)"
+
+default: clean
+	$(MAKE) -C $(KDIR) M=$$PWD
+
+debug: clean
+	$(MAKE) -C $(KDIR) M=$$PWD EXTRA_CFLAGS="-O0 -g -DDEBUG"
+
+clean:
+	$(MAKE) -C $(KDIR) M=$$PWD clean
+
+unload:
+	./modules_load.sh unload
+
+load: unload
+	./modules_load.sh
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,36 @@ Always update your Xbox devices to the latest firmware version!
 Feel free to package `xone` for any Linux distribution or hardware you like.
 Any issues regarding the packaging should be reported to the respective maintainers.
 
+## Building and testing
+
+### Prerequisites
+
+- Linux 5.13+
+- Linux headers
+
+Build the driver
+```shell
+make
+# with debug
+make debug
+```
+
+Load modules from the build directory
+```shell
+sudo make load
+```
+
+Unload all xone modules
+```shell
+# called automatically during load as well
+sudo make unload
+```
+
+Clean all build files
+```shell
+make clean
+```
+
 ## Installation
 
 ### Prerequisites

--- a/modules_load.sh
+++ b/modules_load.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+
+OPERATION="insmod"
+SUFFIX=".ko"
+MESSAGE="Loading"
+
+mapfile -t MODULES_TMP < modules.order
+MODULES=("${MODULES_TMP[@]}")
+
+LOADED_MODULES=$(lsmod)
+
+if [[ $1 == "unload" ]]; then
+    OPERATION="rmmod -f"
+    SUFFIX=""
+    MESSAGE="Unloading"
+
+    # array reversing for rmmod
+    len=${#MODULES[@]}
+    for ((i = 0 ; i < $len ; i++)); do
+        MODULES[$i]=${MODULES_TMP[(( $len - $i - 1 ))]}
+    done
+fi
+
+for module in "${MODULES[@]}"; do
+    module="${module%.o}$SUFFIX"
+
+    # skip rmmod if module is not loaded
+    [[ $1 == "unload" && ! "$LOADED_MODULES" =~ "$module" ]] && continue
+
+    echo "$MESSAGE $module"
+    $OPERATION "$module"
+done


### PR DESCRIPTION
To speed up development/testing. Makefile can easily build, build with debug, clean, load/unload modules with the helper script.

Fixes module order which was wrong. `xone_gip` is the most important.

New helper script can load/unload modules on it's own, but it's best used with the Makefile