### PR TITLE
Fix firmware loading on boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ remove: clean
 install: clean
 	./install.sh
 	./install/firmware.sh --skip-disclaimer
+
+install-debug: clean
+	./install.sh --debug
+	./install/firmware.sh --skip-disclaimer

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ cd xone
 sudo make install
 ```
 
-**NOTE:** You can use the `--debug` flag to enable debug logging.
+**NOTE:** You can use the `install-debug` target instead to enable debug logging.
 
 4. Download the firmware for the wireless dongle (optional, makefile automatically installs firmware):
 

--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -1114,6 +1114,8 @@ static int xone_dongle_resume(struct usb_interface *intf)
 	struct urb *urb;
 	int err;
 
+	msleep(500);
+
 	while ((urb = usb_get_from_anchor(&dongle->urbs_in_idle))) {
 		usb_anchor_urb(urb, &dongle->urbs_in_busy);
 		usb_free_urb(urb);

--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -1039,6 +1039,7 @@ static int xone_dongle_probe(struct usb_interface *intf,
 	dongle->mt.udev = interface_to_usbdev(intf);
 
 	usb_reset_device(dongle->mt.udev);
+	msleep(500);
 
 	dongle->event_wq = alloc_ordered_workqueue("xone_dongle", 0);
 	if (!dongle->event_wq)

--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -30,6 +30,11 @@
 
 #define XONE_DONGLE_PAIRING_TIMEOUT msecs_to_jiffies(30000)
 #define XONE_DONGLE_PWR_OFF_TIMEOUT msecs_to_jiffies(5000)
+#define XONE_DONGLE_FW_REQ_TIMEOUT_MS 1000
+#define XONE_DONGLE_FW_REQ_RETRIES 3
+
+#define XONE_DONGLE_OFFICIAL_VENDOR 0x045e
+#define XONE_DONGLE_OFFICIAL_PRODUCT 0x02fe
 
 enum xone_dongle_queue {
 	XONE_DONGLE_QUEUE_DATA = 0x00,
@@ -472,6 +477,7 @@ static void xone_dongle_handle_event(struct work_struct *work)
 		err = xone_dongle_remove_client(evt->dongle, evt->wcid);
 		break;
 	case XONE_DONGLE_EVT_PAIR_CLIENT:
+		pr_debug("%s: XONE_DONGLE_EVT_PAIR_CLIENT", __func__);
 		err = xone_dongle_pair_client(evt->dongle, evt->address);
 		break;
 	case XONE_DONGLE_EVT_ENABLE_PAIRING:
@@ -855,12 +861,54 @@ static int xone_dongle_init_urbs_out(struct xone_dongle *dongle)
 	return 0;
 }
 
+static int xone_dongle_fw_requester(const struct firmware **fw,
+				    struct device *dev, char *fwname)
+{
+	int err;
+
+	dev_dbg(dev, "%s: trying to load firmware %s\n", __func__, fwname);
+	for (int i = 0; i < XONE_DONGLE_FW_REQ_RETRIES; ++i) {
+		dev_dbg(dev, "%s: attempt: %d\n", __func__, i + 1);
+		err = request_firmware(fw, fwname, dev);
+		if (!err)
+			return 0;
+
+		msleep(XONE_DONGLE_FW_REQ_TIMEOUT_MS);
+	}
+
+	return err;
+}
+
+static int xone_dongle_fw_obtainer(const struct firmware **fw,
+				   struct device *dev, u16 vendor, u16 product)
+{
+	char fwname[25];
+	int err;
+
+	bool official_dongle = (vendor == XONE_DONGLE_OFFICIAL_VENDOR &&
+				product == XONE_DONGLE_OFFICIAL_PRODUCT);
+	/*
+	 * Skip loading "exact" firmware if the official
+	 * Microsoft dongle has been detected
+	 */
+	if (!official_dongle) {
+		snprintf(fwname, 25, "xow_dongle_%04x_%04x.bin", vendor, product);
+		err = xone_dongle_fw_requester(fw, dev, fwname);
+	}
+
+	if (err == -ENOENT || official_dongle) {
+		snprintf(fwname, 15, "xow_dongle.bin");
+		err = xone_dongle_fw_requester(fw, dev, fwname);
+	}
+
+	return err;
+}
+
 static int xone_dongle_init(struct xone_dongle *dongle,
 			    const struct usb_device_id *id)
 {
 	struct xone_mt76 *mt = &dongle->mt;
 	const struct firmware *fw;
-	char fwname[25];
 	int err;
 
 	init_usb_anchor(&dongle->urbs_out_idle);
@@ -882,36 +930,20 @@ static int xone_dongle_init(struct xone_dongle *dongle,
 	if (err)
 		return err;
 
-	/*
-	 * Skip loading "exact" firmware if the official
-	 * Microsoft dongle has been detected
-	 */
-	bool official_dongle =
-		(id->idVendor == 0x045e && id->idProduct == 0x02fe);
-
-	err = 0;
-	if (!official_dongle) {
-		snprintf(fwname, 25, "xow_dongle_%04x_%04x.bin",
-			 id->idVendor, id->idProduct);
-		dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
-			__func__, fwname);
-		err = request_firmware(&fw, fwname, mt->dev);
-	}
-
-	if (err == -ENOENT || official_dongle) {
-		snprintf(fwname, 15, "xow_dongle.bin");
-		dev_dbg(dongle->mt.dev, "%s: trying to load firmware %s\n",
-			__func__, fwname);
-		err = request_firmware(&fw, fwname, mt->dev);
-	}
-
+	err = xone_dongle_fw_obtainer(&fw, mt->dev, id->idVendor, id->idProduct);
 	if (err) {
-		dev_err(mt->dev, "%s: request firmware failed: %d\n",
-			__func__, err);
+		dev_err(mt->dev, "%s: request firmware failed: %d\n", __func__,
+			err);
 		return err;
 	}
 
-	err = xone_mt76_load_firmware(mt, fw);
+	for (int i = 0; i < XONE_DONGLE_FW_REQ_RETRIES; ++i) {
+		err = xone_mt76_load_firmware(mt, fw);
+		if (!err)
+			break;
+
+		msleep(XONE_DONGLE_FW_REQ_TIMEOUT_MS);
+	}
 	release_firmware(fw);
 	if (err) {
 		dev_err(mt->dev, "%s: load firmware failed: %d\n",


### PR DESCRIPTION
Sometimes the firmawre load on cold boot fails. Add retries and sleeps to work around this issue.

Fixes # 61 (hopefully)