### PR TITLE
Fix initialization for Razer Headsets

### DIFF
--- a/bus/protocol.c
+++ b/bus/protocol.c
@@ -352,15 +352,13 @@ static int gip_send_pkt_simple(struct gip_client *client,
 
 	/* debug message sent */
 	gip_dbg(client, "%s: cmd=0x%02x len=0x%04x seq=0x%02x offset=0x%04x\n",
-		__func__,
-		hdr->command, buf.length, hdr->sequence,
+		__func__, hdr->command, buf.length, hdr->sequence,
 		hdr->chunk_offset);
 
 	/* always fails on adapter removal */
 	err = adap->ops->submit_buffer(adap, &buf);
 	if (err)
-		gip_dbg(client, "%s: submit buffer failed: %d\n",
-			__func__, err);
+		gip_dbg(client, "%s: submit buffer failed: %d\n", __func__, err);
 
 err_unlock:
 	spin_unlock_irqrestore(&adap->send_lock, flags);
@@ -417,7 +415,7 @@ static int gip_acknowledge_pkt(struct gip_client *client,
 
 	if ((ack->options & GIP_OPT_CHUNK) && buf)
 		pkt.remaining = cpu_to_le16(buf->length - len);
-	
+
 	gip_dbg(client, "%s: ACME(host) command=0x%02x, length=0x%04x\n",
 		__func__, pkt.command, len);
 
@@ -1038,8 +1036,8 @@ static int gip_send_remaining_chunks(struct gip_client *client, u32 offset)
 	u32 len = buf->length - offset;
 	int err;
 
-	gip_dbg(client, "%s: sending chunk 0x%04x/0x%04x/0x%04x\n",
-		__func__, len, hdr.chunk_offset, buf->length);
+	gip_dbg(client, "%s: sending chunk 0x%04x/0x%04x/0x%04x\n", __func__,
+		len, hdr.chunk_offset, buf->length);
 
 	int coalesce_count = GIP_PKT_COALESCE_COUNT;
 	while (len && coalesce_count) {
@@ -1075,9 +1073,9 @@ static int gip_handle_pkt_acknowledge(struct gip_client *client,
 	if (!buf)
 		return 0;
 
-	gip_dbg(client,"%s: ACME(dev) cmd=0x%02x/0x%02x, len=0x%04x/0x%04x\n",
-			__func__, pkt->command, buf->header.command,
-			le16_to_cpu(pkt->length), buf->length);
+	gip_dbg(client, "%s: ACME(dev) cmd=0x%02x/0x%02x, len=0x%04x/0x%04x\n",
+		__func__, pkt->command, buf->header.command,
+		le16_to_cpu(pkt->length), buf->length);
 
 	/* acknowledgment for different command */
 	if (pkt->command != buf->header.command)
@@ -1088,8 +1086,7 @@ static int gip_handle_pkt_acknowledge(struct gip_client *client,
 	 * so sanitize value to prevent buffer overflow.
 	 */
 	if (le16_to_cpu(pkt->length) < buf->length)
-		return gip_send_remaining_chunks(
-			client, le16_to_cpu(pkt->length));
+		return gip_send_remaining_chunks(client, le16_to_cpu(pkt->length));
 
 	gip_dbg(client, "%s: all chunks sent\n", __func__);
 

--- a/driver/headset.c
+++ b/driver/headset.c
@@ -21,15 +21,15 @@
 /* product ID for the chat headset */
 #define GIP_HS_PID_CHAT 0x0111
 
-#define GIP_HS_MAX_RETRIES  6
+#define GIP_HS_MAX_RETRIES 6
 #define GIP_HS_POWER_ON_DELAY msecs_to_jiffies(250)
 #define GIP_HS_START_DELAY msecs_to_jiffies(500)
 
 static struct gip_vidpid GIP_HS_CHECK_AUTH_IDS[] = {
-	{0x1532, 0x0a16}, // Razer Thresher
-	{0x1532, 0x0a25}, // Razer Kaira Pro
-	{0x1532, 0x0a27}, // Razer Kaira Pro
-	{0x2f12, 0x0023}, // LucidSound LS35X
+	{ 0x1532, 0x0a16 }, // Razer Thresher
+	{ 0x1532, 0x0a25 }, // Razer Kaira Pro
+	{ 0x1532, 0x0a27 }, // Razer Kaira Pro
+	{ 0x2f12, 0x0023 }, // LucidSound LS35X
 };
 
 static const struct snd_pcm_hardware gip_headset_pcm_hw = {
@@ -55,7 +55,7 @@ struct gip_headset {
 	struct delayed_work work_power_on;
 	struct work_struct work_register;
 	bool got_authenticated;
-	int  start_counter;
+	int start_counter;
 	bool got_initial_volume;
 	bool got_audio_packet;
 
@@ -283,32 +283,33 @@ static enum hrtimer_restart gip_headset_send_samples(struct hrtimer *timer)
 	return HRTIMER_RESTART;
 }
 
-/* 
+/*
  * start pcm devices then launch the work that
  * sends START every 500ms until an audio packet is received
  * or audio volume control command is received
  * or time out of 3 seconds (5 start message + 500ms timeout)
  */
-static enum hrtimer_restart gip_headset_start_audio(struct hrtimer *timer) {
-	struct gip_headset *headset = container_of(timer, typeof(*headset),
-						   start_audio_timer);
+static enum hrtimer_restart gip_headset_start_audio(struct hrtimer *timer)
+{
+	struct gip_headset *headset =
+		container_of(timer, typeof(*headset), start_audio_timer);
 	int err;
+
 	/*
 	 * check if the number of retries are elapsed (5) :
 	 * start audio anyway
 	 */
-	bool max_retries_reached = 
-		(headset->start_counter > GIP_HS_MAX_RETRIES ? true : false );
+	bool max_retries_reached =
+		(headset->start_counter > GIP_HS_MAX_RETRIES ? true : false);
+
 	/* check here if audio was started : HRTIMER_NORESTART */
-	if (headset->got_initial_volume
-	    || headset->got_audio_packet
-	    || max_retries_reached) {
+	if (headset->got_initial_volume || headset->got_audio_packet ||
+	    max_retries_reached) {
 		dev_dbg(&headset->client->dev,
 			"%s: start audio try %d/%d, audio = %d, vol = %d.\n",
-			__func__, headset->start_counter,
-			GIP_HS_MAX_RETRIES,
-			headset->got_audio_packet,
-			headset->got_initial_volume);
+			__func__, headset->start_counter, GIP_HS_MAX_RETRIES,
+			headset->got_audio_packet, headset->got_initial_volume);
+
 		/* start work handling pcm config and audio timer */
 		schedule_work(&headset->work_register);
 		return HRTIMER_NORESTART;
@@ -321,8 +322,7 @@ static enum hrtimer_restart gip_headset_start_audio(struct hrtimer *timer) {
 	err = gip_set_power_mode(headset->client, GIP_PWR_ON);
 	if (err)
 		dev_err(&headset->client->dev,
-			"%s: set power mode failed: %d\n",
-			__func__, err);
+			"%s: set power mode failed: %d\n", __func__, err);
 	hrtimer_forward_now(timer, ms_to_ktime(GIP_HS_START_DELAY));
 
 	return HRTIMER_RESTART;
@@ -388,9 +388,8 @@ static void gip_headset_config(struct work_struct *work)
 
 static void gip_headset_power_on(struct work_struct *work)
 {
-	struct gip_headset *headset = container_of(to_delayed_work(work),
-						   typeof(*headset),
-						   work_power_on);
+	struct gip_headset *headset = container_of(
+		to_delayed_work(work), typeof(*headset), work_power_on);
 	struct gip_client *client = headset->client;
 	const struct device *dev = &client->adapter->dev;
 	int err;


### PR DESCRIPTION
- Merges all fixes tested in [PR75](https://github.com/dlundqvist/xone/pull/75) except for LS35X that remains to be fixed and needs a deep dive into windows GIP stack
- Adds logs to debug GIP gamepads / headsets messages if needed in the future
- Proper implementation of ACME offset which may cause reliable messaging to fail with wireless devices (not really a major issue but may happen)

Tested on Xbox Genuine controller + analog headset plugged in
I do not have any usb dongles to reproduce the testing of CaioEmPessoa nor Benehmb, but the code should be the same as [PR75](https://github.com/dlundqvist/xone/pull/75) with all other recent commits merged