### PR TITLE
Fix rumble being weaker vs windows rumble

### DIFF
--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -26,7 +26,7 @@
 #define GIP_ELITE_SERIES_2_510_FIRMWARE 0x050A
 
 #define GIP_GP_RUMBLE_DELAY msecs_to_jiffies(10)
-#define GIP_GP_RUMBLE_MAX 100
+#define GIP_GP_RUMBLE_MAX 255
 
 /* button offset from end of packet */
 #define GIP_GP_BTN_SHARE_OFFSET 18


### PR DESCRIPTION
I noticed that when comparing the rumble in Forza Horizon 5 on windows vs linux, the rumble was way higher in windows.

After this change, the rumble intensity is the same between both.

This may help https://github.com/dlundqvist/xone/issues/83 -- since `GIP_GP_RUMBLE_MAX` was less than 1/2, maybe it wasn't enough to trigger off the impulse triggers on that different hardware, or might have been low enough that it seemed like it wasn't rumbling.