### PR TITLE
Increase the dongle pairing timout

### DIFF
--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -26,7 +26,7 @@
 
 #define XONE_DONGLE_MAX_CLIENTS 16
 
-#define XONE_DONGLE_PAIRING_TIMEOUT msecs_to_jiffies(30000)
+#define XONE_DONGLE_PAIRING_TIMEOUT msecs_to_jiffies(60000)
 #define XONE_DONGLE_PWR_OFF_TIMEOUT msecs_to_jiffies(5000)
 #define XONE_DONGLE_FW_REQ_TIMEOUT_MS 3000
 #define XONE_DONGLE_FW_REQ_RETRIES 11 // 30 seconds


### PR DESCRIPTION
Sometimes 30 seconds is just not enough for devices to find themselves.
Pairing timout changed to 60 seconds to allow for more wiggle room and
less frustration