### PR TITLE
Remove unreachable code in xone_dongle_resume()

### DIFF
--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -1181,8 +1181,6 @@ static int xone_dongle_resume(struct usb_interface *intf)
 
 	msleep(1000);
 	return xone_mt76_resume_radio(&dongle->mt);
-	msleep(500);
-	return xone_mt76_resume_radio(&dongle->mt);
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)


### PR DESCRIPTION
Apologies for the pedantic PR, but there are two unreachable lines in `xone_dongle_resume()` that were accidentally introduced in commit cfc3d83.

The current code:
```c
msleep(1000);
return xone_mt76_resume_radio(&dongle->mt);
msleep(500);
return xone_mt76_resume_radio(&dongle->mt);
```

The `msleep(500)` and second return statement can never execute due to the return on the line above. This PR simply removes the dead code.