### PR TITLE
Add sysfs interface to power off wireless controllers

### DIFF
--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -347,21 +347,16 @@ static ssize_t poweroff_store(struct device *dev, struct device_attribute *attr,
 	if (dongle->fw_state != XONE_DONGLE_FW_STATE_READY)
 		return -ENODEV;
 
-	err = kstrtoint(buf, 2, &val);
+	err = kstrtoint(buf, 10, &val);
 	if (err)
 		return err;
 
 	if (val == -1)
 		err = xone_dongle_power_off_clients(dongle);
-	else if (val >= 0 && val < atomic_read(&dongle->client_count))
-		err = xone_dongle_power_off_client(dongle, val);
 	else
-		err = -EINVAL;
+		err = xone_dongle_power_off_client(dongle, val);
 
-	if (err)
-		return err;
-
-	return count;
+	return err ? err : count;
 }
 
 DEVICE_ATTR_RW(pairing);


### PR DESCRIPTION
Adds a `poweroff` sysfs attribute to the dongle driver so users can disconnect controllers from userspace. This was discussed on the discord for use cases like cleanly powering off controllers when a system service stops. 

Reading the attribute returns the number of connected controllers. Writing a negative value (such as `-1`) powers off all controllers, while writing an index from 0 to 15 (matching `XONE_DONGLE_MAX_CLIENTS`) powers off that specific controller. 

The implementation reuses the existing `xone_dongle_power_off_clients` function which is already called during shutdown and suspend. I apologize for adding a forward declaration (it seemed better than changing the logical grouping of either sysfs or cleanup sections). 

This should be testable with:

```bash
# show number of connected controllers
cat /sys/bus/usb/drivers/xone-dongle/*/poweroff

# power off all controllers
echo -1 | sudo tee /sys/bus/usb/drivers/xone-dongle/*/poweroff

# power off first controller (index 0)
echo 0 | sudo tee /sys/bus/usb/drivers/xone-dongle/*/poweroff
```

I don't have a wireless dongle to test with, so if someone else does a quick test to make sure it works via the above would be greatly appreciated :) 