### PR TITLE
Fix boot loop and improve suspend/resume reconnection

### DIFF
--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -1474,17 +1474,62 @@ static int xone_dongle_post_reset(struct usb_interface *intf)
 static int xone_dongle_reset_resume(struct usb_interface *intf)
 {
 	struct xone_dongle *dongle = usb_get_intfdata(intf);
-	int err;
+	struct xone_dongle_client *client;
+	struct urb *urb;
+	int i;
 
 	pr_debug("%s", __func__);
 
-	err = usb_reset_device(dongle->mt.udev);
-	if (err == -EINPROGRESS) {
-		pr_debug("%s: Reset already in progress", __func__);
-		return 0;
+	/*
+	 * The kernel already reset the USB device before calling
+	 * reset_resume — a second usb_reset_device() is redundant and
+	 * can leave the XHCI port in a bad state (the same class of bug
+	 * as the former usb_reset_device() call in probe).
+	 *
+	 * Instead, clean up all stale state and reinitialize from scratch.
+	 * This also ensures old GIP adapters are destroyed so the
+	 * reconnecting controller gets a fresh input device.
+	 */
+	if (dongle->fw_state < XONE_DONGLE_FW_STATE_ERROR)
+		dongle->fw_state = XONE_DONGLE_FW_STATE_STOP_LOADING;
+
+	usb_kill_anchored_urbs(&dongle->urbs_in_busy);
+	cancel_work_sync(&dongle->load_fw_work);
+	/*
+	 * If load_fw_work raced past the STOP_LOADING check and created
+	 * new URBs before cancel_work_sync returned, kill them now.
+	 */
+	usb_kill_anchored_urbs(&dongle->urbs_in_busy);
+	drain_workqueue(dongle->event_wq);
+	cancel_delayed_work_sync(&dongle->pairing_work);
+	cancel_delayed_work_sync(&dongle->pairing_scan_work);
+
+	for (i = 0; i < XONE_DONGLE_MAX_CLIENTS; i++) {
+		client = dongle->clients[i];
+		if (!client)
+			continue;
+		gip_destroy_adapter(client->adapter);
+		kfree(client);
+		dongle->clients[i] = NULL;
+	}
+	atomic_set(&dongle->client_count, 0);
+
+	usb_kill_anchored_urbs(&dongle->urbs_out_busy);
+
+	while ((urb = usb_get_from_anchor(&dongle->urbs_out_idle)))
+		usb_free_urb(urb);
+
+	while ((urb = usb_get_from_anchor(&dongle->urbs_in_idle))) {
+		usb_free_coherent(urb->dev, urb->transfer_buffer_length,
+				  urb->transfer_buffer, urb->transfer_dma);
+		usb_free_urb(urb);
 	}
 
-	return err;
+	dongle->pairing = false;
+	dongle->pairing_scan_idx = 0;
+	dongle->last_wlan_rx = 0;
+
+	return xone_dongle_init(dongle);
 }
 
 static const struct usb_device_id xone_dongle_id_table[] = {

--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -303,12 +303,6 @@ static int xone_dongle_toggle_pairing(struct xone_dongle *dongle, bool enable)
 					   XONE_DONGLE_PAIRING_TIMEOUT);
 }
 
-static int xone_dongle_enable_pairing(struct xone_dongle *dongle,
-				      u8 timeout_secs)
-{
-	return xone_dongle_pairing_handler(dongle, true, timeout_secs);
-}
-
 static void xone_dongle_pairing_timeout(struct work_struct *work)
 {
 	struct xone_dongle *dongle = container_of(to_delayed_work(work),
@@ -1182,12 +1176,13 @@ static void xone_dongle_fw_load(struct work_struct *work)
 	 * In this state already-paired controllers cannot reconnect: they see
 	 * the beacon but are rejected by the filter.
 	 *
-	 * Enable pairing for 10 seconds so controllers present at boot or
-	 * after a replug reconnect automatically without requiring a manual
-	 * button press. The pairing timeout (XONE_DONGLE_PAIRING_TIMEOUT)
-	 * disables it again once the window expires.
+	 * Enable pairing so controllers present at boot or after a replug
+	 * reconnect automatically without requiring a manual button press.
+	 * The channel scan cycles through all 12 channels at 2 s each
+	 * (24 s per full cycle), so the timeout must be long enough for
+	 * at least two full cycles.  Use the default 60 s timeout.
 	 */
-	err = xone_dongle_enable_pairing(dongle, 10);
+	err = xone_dongle_toggle_pairing(dongle, true);
 	if (err)
 		dev_err(mt->dev, "%s: enable pairing failed: %d\n",
 			__func__, err);

--- a/transport/mt76.c
+++ b/transport/mt76.c
@@ -518,7 +518,6 @@ int xone_mt76_load_firmware(struct xone_mt76 *mt, const struct firmware *fw)
 	int err;
 
 	if (xone_mt76_read_register(mt, MT_FCE_DMA_ADDR | MT_VEND_TYPE_CFG)) {
-		msleep(2000);
 		dev_dbg(mt->dev, "%s: resetting firmware...\n", __func__);
 		err = xone_mt76_reset_firmware(mt);
 		if (err)


### PR DESCRIPTION
## Summary

While investigating reconnection issues reported in #162, #156 and #183, we found three changes that may help:

- **Remove 2 s delay before firmware reset** (`mt76.c`) — The `msleep(2000)` added in v0.5.6 before `reset_firmware()` appears to cause the boot loop described in #183. On the old dongle (`045e:02e6`), `MT_FCE_DMA_ADDR` can read non-zero on cold boot (stale SRAM?), taking the reset path. The 2 s stall seems long enough for the USB subsystem to disconnect the device, which then re-enumerates and loops. The dmesg timing in #183 (~2.2 s gap) is consistent with this, and [the regression was confirmed](https://github.com/dlundqvist/xone/issues/183#issuecomment-4008466481) between v0.5.5 and v0.5.6. The `msleep(500)` after `reset_firmware` and the retry loop in `fw_load` should provide sufficient robustness without the pre-reset delay.

- **Restore 60 s pairing timeout** (`dongle.c`) — As [discussed in #181](https://github.com/dlundqvist/xone/pull/181#issuecomment-3974820725), the 10 s timeout is too short for the channel scan which needs 24 s for a full cycle through all 12 channels. In @prachtsteve's [suspend/resume test](https://github.com/dlundqvist/xone/issues/162#issuecomment-3971419669), the controller was only found after ~60 s. Also removes the now-unused `xone_dongle_enable_pairing()`.

- **Reinitialize directly in `reset_resume`** (`dongle.c`) — When the kernel calls `reset_resume`, the USB device has already been reset by the hub driver. Calling `usb_reset_device()` again may be redundant and could cause issues on some hardware — similar to the former `usb_reset_device()` in probe that we removed earlier. The new code does a full cleanup (stop work, drain events, destroy stale GIP adapters/clients, free URBs) then reinitializes from scratch. Destroying stale GIP adapters may explain why @prachtsteve's [test](https://github.com/dlundqvist/xone/issues/162#issuecomment-3971419669) saw the wireless link re-establish but no input devices appear.

## Caveats

We can only test with our own hardware (Xbox Elite Series 2 + Xbox Wireless Controller, dongle `045e:02fe`). The boot loop in #183 affects the old dongle (`045e:02e6`) which we don't have, so the first commit is based on dmesg analysis rather than direct reproduction. The suspend/resume issues in #162 and #156 depend on USB hub behavior during sleep which varies across machines. Feedback from affected users would be very welcome.