### PR TITLE
Add Trigger rumble by pressure, like xpadneo

### DIFF
--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -11,7 +11,7 @@
 #include "common.h"
 #include "../auth/auth.h"
 
-ushort trigger_rumble_mode = 0;
+ushort trigger_rumble_mode = 2;
 MODULE_PARM_DESC(trigger_rumble_mode, "Trigger rumble mode. 0: pressure, 2: disable.");
 module_param(trigger_rumble_mode, ushort, 0644);
 

--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -173,8 +173,8 @@ static int gip_gamepad_queue_rumble(struct input_dev *dev, void *data,
 				    struct ff_effect *effect)
 {
 	struct gip_gamepad_rumble *rumble = input_get_drvdata(dev);
-	u16 mag_left = effect->u.rumble.strong_magnitude;
-	u16 mag_right = effect->u.rumble.weak_magnitude;
+	u32 mag_left = effect->u.rumble.strong_magnitude;
+	u32 mag_right = effect->u.rumble.weak_magnitude;
 	unsigned long flags;
 
 	if (effect->type != FF_RUMBLE)
@@ -182,8 +182,8 @@ static int gip_gamepad_queue_rumble(struct input_dev *dev, void *data,
 
 	spin_lock_irqsave(&rumble->lock, flags);
 
-	rumble->pkt.left = mag_left * GIP_GP_RUMBLE_MAX / U16_MAX;
-	rumble->pkt.right = mag_right * GIP_GP_RUMBLE_MAX / U16_MAX;
+	rumble->pkt.left = (mag_left * GIP_GP_RUMBLE_MAX + S16_MAX) / U16_MAX;
+	rumble->pkt.right = (mag_right * GIP_GP_RUMBLE_MAX + S16_MAX) / U16_MAX;
 
 	/* delay rumble to work around firmware bug */
 	if (!timer_pending(&rumble->timer))

--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -25,8 +25,10 @@
 #define GIP_ELITE_SERIES_2_4X_FIRMWARE 0x04FF
 #define GIP_ELITE_SERIES_2_510_FIRMWARE 0x050A
 
-#define GIP_GP_RUMBLE_DELAY msecs_to_jiffies(10)
+#define GIP_GP_RUMBLE_DELAY msecs_to_jiffies(20)
+#define GIP_GP_RUMBLE_TRIGGER_DELAY msecs_to_jiffies(50)
 #define GIP_GP_RUMBLE_MAX 100
+#define GIP_GP_RUMBLE_TRIGGER_MAX 100
 
 /* button offset from end of packet */
 #define GIP_GP_BTN_SHARE_OFFSET 18
@@ -131,6 +133,11 @@ struct gip_gamepad_rumble {
 	struct timer_list timer;
 	struct gip_gamepad_pkt_rumble pkt;
 
+	u8 main_left;
+	u8 main_right;
+	u16 trig_pos_left;
+	u16 trig_pos_right;
+
 	struct gip_gamepad *parent;
 };
 
@@ -163,6 +170,29 @@ static void gip_gamepad_send_rumble(struct timer_list *timer)
 
 	spin_lock_irqsave(&rumble->lock, flags);
 
+	u8 left_main = rumble->main_left;
+	u8 right_main = rumble->main_right;
+
+	u16 trig_l = rumble->trig_pos_left;
+	u16 trig_r = rumble->trig_pos_right;
+
+	u8 pct_l = (trig_l * GIP_GP_RUMBLE_TRIGGER_MAX + 511) / 1023;
+	u8 pct_r = (trig_r * GIP_GP_RUMBLE_TRIGGER_MAX + 511) / 1023;
+
+	/*
+	 * we want to keep the rumbling at the triggers at the maximum
+	 * of the weak and strong main rumble
+	 */
+	u8 max_main = max(left_main, right_main);
+
+	u8 left_trigger = (max_main * pct_l + 50) / 100;
+	u8 right_trigger = (max_main * pct_r + 50) / 100;
+
+	rumble->pkt.left = left_main;
+	rumble->pkt.right = right_main;
+	rumble->pkt.left_trigger = left_trigger;
+	rumble->pkt.right_trigger = right_trigger;
+
 	gip_send_rumble(gamepad->client, &rumble->pkt, sizeof(rumble->pkt));
 	rumble->last = jiffies;
 
@@ -182,8 +212,8 @@ static int gip_gamepad_queue_rumble(struct input_dev *dev, void *data,
 
 	spin_lock_irqsave(&rumble->lock, flags);
 
-	rumble->pkt.left = (mag_left * GIP_GP_RUMBLE_MAX + S16_MAX) / U16_MAX;
-	rumble->pkt.right = (mag_right * GIP_GP_RUMBLE_MAX + S16_MAX) / U16_MAX;
+	rumble->main_left = (mag_left * GIP_GP_RUMBLE_MAX + S16_MAX) / U16_MAX;
+	rumble->main_right = (mag_right * GIP_GP_RUMBLE_MAX + S16_MAX) / U16_MAX;
 
 	/* delay rumble to work around firmware bug */
 	if (!timer_pending(&rumble->timer))
@@ -379,13 +409,26 @@ static int gip_gamepad_op_firmware(struct gip_client *client, void *data,
 static int gip_gamepad_op_input(struct gip_client *client, void *data, u32 len)
 {
 	struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
+	struct gip_gamepad_rumble *rumble = &gamepad->rumble;
 	struct gip_gamepad_pkt_input *pkt = data;
 	struct input_dev *dev = gamepad->input.dev;
 	u16 buttons;
 	u8 share_offset = GIP_GP_BTN_SHARE_OFFSET;
+    unsigned long flags;
 
 	if (len < sizeof(*pkt))
 		return -EINVAL;
+
+	spin_lock_irqsave(&rumble->lock, flags);
+
+	rumble->trig_pos_left = le16_to_cpu(pkt->trigger_left);
+	rumble->trig_pos_right = le16_to_cpu(pkt->trigger_right);
+
+	/* delay rumble to work around firmware bug */
+	if (!timer_pending(&rumble->timer))
+		mod_timer(&rumble->timer, rumble->last + GIP_GP_RUMBLE_TRIGGER_DELAY);
+
+	spin_unlock_irqrestore(&rumble->lock, flags);
 
 	buttons = le16_to_cpu(pkt->buttons);
 

--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -11,6 +11,10 @@
 #include "common.h"
 #include "../auth/auth.h"
 
+ushort trigger_rumble_mode = 0;
+MODULE_PARM_DESC(trigger_rumble_mode, "Trigger rumble mode. 0: pressure, 2: disable.");
+module_param(trigger_rumble_mode, ushort, 0644);
+
 #define GIP_GP_NAME "Microsoft Xbox Controller"
 
 #define GIP_VENDOR_MICROSOFT 0x045e
@@ -190,8 +194,8 @@ static void gip_gamepad_send_rumble(struct timer_list *timer)
 
 	rumble->pkt.left = left_main;
 	rumble->pkt.right = right_main;
-	rumble->pkt.left_trigger = left_trigger;
-	rumble->pkt.right_trigger = right_trigger;
+	rumble->pkt.left_trigger = trigger_rumble_mode == 2 ? 0 : left_trigger;
+	rumble->pkt.right_trigger = trigger_rumble_mode == 2 ? 0 : right_trigger;
 
 	gip_send_rumble(gamepad->client, &rumble->pkt, sizeof(rumble->pkt));
 	rumble->last = jiffies;


### PR DESCRIPTION
Port [from xpadneo](https://github.com/atar-axis/xpadneo/blob/d67479f7c02bd0537901242b8ecfee5cc8e16ab1/hid-xpadneo/src/xpadneo/rumble.c#L149) with AI coding and my human testing.
I revert commit https://github.com/dlundqvist/xone/commit/a7a62711c97b99ab5c5d620aa122330331e5d12e because after that, the weak motor stops rumbling with 0.01 intensity on my Xbox One S controller(tested with https://gpadtester.net/vibration-test/), causing some games to lose some rumble details.