### PR TITLE
fix(gamepad): add delayed authentication for PDP-like gamepads and legacy headsets

### DIFF
--- a/bus/bus.h
+++ b/bus/bus.h
@@ -56,6 +56,7 @@ struct gip_adapter {
 	spinlock_t send_lock;
 
 	u8 data_sequence;
+  u8 auth_sequence;
 	u8 audio_sequence;
 };
 

--- a/bus/protocol.c
+++ b/bus/protocol.c
@@ -323,6 +323,17 @@ static int gip_decode_header(struct gip_header *hdr, u8 *data, int len)
 	return hdr_len;
 }
 
+static int gip_has_capability(struct gip_info_element *caps, u8 command)
+{
+  for(int i=0; i<caps->count; i++) {
+    if (caps->data[i] == command) {
+      return 0;
+    }
+  }
+  return -ENOTSUPP;
+}
+
+
 static int gip_init_chunk_buffer(struct gip_client *client,
 				 struct gip_header *hdr,
 				 struct gip_chunk_buffer **buf,
@@ -388,6 +399,15 @@ static int gip_send_pkt_simple(struct gip_client *client,
 
 	/* set actual length */
 	buf.length = hdr_len + hdr->packet_length;
+
+	gip_dbg(client, "%s:  seq=0x%02x, cmd=0x%02x, len=0x%04x flags=[%s %s %s] pkt=[%*ph]\n",
+		__func__,
+    hdr->sequence,
+		hdr->command, hdr->packet_length,
+		hdr->options & GIP_OPT_CHUNK_START? "Ini":"...",
+		hdr->options & GIP_OPT_ACKNOWLEDGE? "Ack":"...",
+		hdr->options & GIP_OPT_INTERNAL? "Sys":"...",
+    buf.length,buf.data);
 
 	/* debug message sent */
 	// gip_dbg(client, "%s: cmd=0x%02x len=0x%04x seq=0x%02x offset=0x%04x\n",
@@ -455,8 +475,8 @@ static int gip_acknowledge_pkt(struct gip_client *client,
 	if ((ack->options & GIP_OPT_CHUNK) && buf)
 		pkt.remaining = cpu_to_le16(buf->length - len);
 
-	// gip_dbg(client, "%s: ACME(host) command=0x%02x, length=0x%04x\n",
-	// 	__func__, pkt.command, len);
+	gip_dbg(client, "%s:  seq=0x%02x, cmd=0x%02x, len=0x%04x ACME(host)\n",
+	        __func__, hdr.sequence, pkt.command, len);
 
 	return gip_send_pkt(client, &hdr, &pkt);
 }
@@ -494,6 +514,12 @@ int gip_send_authenticate(struct gip_client *client, void *pkt, u32 len,
 	hdr.command = GIP_CMD_AUTHENTICATE;
 	hdr.options = client->id | GIP_OPT_INTERNAL;
 	hdr.packet_length = len;
+
+  /* sequence number is always greater than zero */
+  if (!++client->adapter->auth_sequence)
+    ++client->adapter->auth_sequence;
+
+  hdr.sequence = client->adapter->auth_sequence;
 
 	if (acknowledge)
 		hdr.options |= GIP_OPT_ACKNOWLEDGE;
@@ -611,6 +637,11 @@ EXPORT_SYMBOL_GPL(gip_set_led_mode);
 
 int gip_send_get_serial_number(struct gip_client *client)
 {
+  int ierr = gip_has_capability(client->capabilities_out, GIP_CMD_EXTENDED);
+  if (ierr) {
+    gip_warn(client,"%s: no GIP_OPT_INTERNAL capability, skipping message.",__func__);
+    return ierr;
+  }
 	struct gip_header hdr = {
 		.command = GIP_CMD_EXTENDED,
 		.options = client->id | GIP_OPT_INTERNAL,
@@ -1118,11 +1149,15 @@ static int gip_handle_pkt_acknowledge(struct gip_client *client,
 	if (len != sizeof(*pkt))
 		return -EINVAL;
 
-	if (!buf)
-		return 0;
+	if (!buf) {
+    gip_dbg(client, "%s:     cmd=0x%02x, len=0x%04x ACME(dev)\n",
+      __func__, pkt->command, le16_to_cpu(pkt->length));
 
-	gip_dbg(client, "%s: ACME(dev) cmd=0x%02x/0x%02x, len=0x%04x/0x%04x\n",
-		__func__, pkt->command, buf->header.command,
+		return 0;
+  }
+
+	gip_dbg(client, "%s: seq=0x%02x, cmd=0x%02x, len=0x%04x/0x%04x ACME(dev)\n",
+		__func__, buf->header.sequence, pkt->command, 
 		le16_to_cpu(pkt->length), buf->length);
 
 	/* acknowledgment for different command */
@@ -1609,11 +1644,8 @@ static int gip_process_pkt_chunked(struct gip_client *client,
 	int err;
 	u32 len;
 
-	gip_dbg(client, "%s: flags=[%s %s %s], offset=0x%04x, length=0x%04x\n",
+	gip_dbg(client, "%s: offset=0x%04x, length=0x%04x\n",
 		__func__,
-		hdr->options & GIP_OPT_CHUNK_START? "Ini":"...",
-		hdr->options & GIP_OPT_ACKNOWLEDGE? "Ack":"...",
-		hdr->options & GIP_OPT_INTERNAL? "Sys":"...",
 		hdr->chunk_offset, hdr->packet_length);
 
 	if (!buf) {
@@ -1700,6 +1732,15 @@ int gip_process_buffer(struct gip_adapter *adap, void *data, int len)
 		client = gip_get_client(adap, hdr.options & GIP_HDR_CLIENT_ID);
 		if (IS_ERR(client))
 			return PTR_ERR(client);
+
+    gip_dbg(client, "%s:   seq=0x%02x, cmd=0x%02x, len=0x%04x flags=[%s %s %s] data=[%*ph]\n",
+      __func__,
+      hdr.sequence,
+      hdr.command, hdr.packet_length,
+      hdr.options & GIP_OPT_CHUNK_START? "Ini":"...",
+      hdr.options & GIP_OPT_ACKNOWLEDGE? "Ack":"...",
+      hdr.options & GIP_OPT_INTERNAL? "Sys":"...",
+      len,data);
 
 		err = gip_process_pkt(client, &hdr, data + hdr_len);
 		if (err)

--- a/bus/protocol.c
+++ b/bus/protocol.c
@@ -1706,6 +1706,7 @@ static int gip_process_pkt(struct gip_client *client,
 		hdr->chunk_offset = 0;
 	}
 
+	/* some gamepads send empty packets with chunk flag : dispatch them */
 	if (hdr->options & GIP_OPT_CHUNK)
 		return gip_process_pkt_chunked(client, hdr, data);
 

--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -78,6 +78,10 @@ enum gip_gamepad_motor {
 	GIP_GP_MOTOR_LT = BIT(3),
 };
 
+enum gip_init_state {
+	GIP_GP_AUTHENTICATING = 0x10,
+	GIP_GP_READY = 0xFF,
+};
 /*
  * Remember, xpad keeps the 4 bytes.
  * Paddles are at [18] in xpad, so, [14] here.
@@ -141,11 +145,15 @@ struct gip_gamepad {
 	struct gip_led led;
 	struct gip_input input;
 
+  //u8 state;
+
 	bool supports_share;
 	bool supports_dli;
 	PaddleCapability paddle_support;
 
 	struct gip_gamepad_rumble rumble;
+
+  //  struct work_struct state_work;
 };
 
 static void gip_gamepad_send_rumble(struct timer_list *timer)
@@ -329,6 +337,14 @@ static int gip_gamepad_op_battery(struct gip_client *client,
 
 	gip_report_battery(&gamepad->battery, type, level);
 
+  // handle pdp gamepad that need delayed authentication
+  /*
+  if (gamepad->state == GIP_GP_AUTHENTICATING)
+  {
+    gamepad->state = GIP_GP_READY;
+    schedule_work(&gamepad->state_work);
+  }*/
+
 	return 0;
 }
 
@@ -352,8 +368,25 @@ static int gip_gamepad_op_guide_button(struct gip_client *client, bool down)
 
 static int gip_gamepad_op_authenticated(struct gip_client *client)
 {
+  struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
+	int err = gip_gamepad_init_input(gamepad);
+	if (err)
+		return err;
+
 	return 0;
 }
+
+/*
+static void gip_gamepad_start_handshake(struct work_struct *work)
+{
+	struct gip_gamepad *gamepad = container_of(work, struct gip_gamepad, state_work);
+	int err = gip_auth_start_handshake(&gamepad->auth, gamepad->client);
+	if (err) {
+		dev_dbg(&gamepad->client->dev, "%s: gamepad handshake failed err=%d.\n", __func__, err);
+		return;
+	}
+}
+*/
 
 static int gip_gamepad_op_firmware(struct gip_client *client, void *data,
 				   u32 len)
@@ -485,6 +518,10 @@ static int gip_gamepad_probe(struct gip_client *client)
 	if (!gamepad)
 		return -ENOMEM;
 
+
+  //INIT_WORK(&gamepad->state_work, gip_gamepad_start_handshake);
+  //gamepad->state = GIP_GP_READY;//AUTHENTICATING;
+
 	gamepad->client = client;
 
 	err = gip_set_power_mode(client, GIP_PWR_ON);
@@ -512,18 +549,18 @@ static int gip_gamepad_probe(struct gip_client *client)
 	if (err)
 		return err;
 
-	err = gip_auth_start_handshake(&gamepad->auth, client);
-	if (err)
-		return err;
-
+  dev_dbg(&gamepad->client->dev, "%s: before gip_init_input.\n", __func__);
 	err = gip_init_input(&gamepad->input, client, GIP_GP_NAME);
 	if (err)
 		return err;
 
-	err = gip_gamepad_init_input(gamepad);
-	if (err)
+  dev_dbg(&gamepad->client->dev, "%s: before handshake.\n", __func__);
+	err = gip_auth_start_handshake(&gamepad->auth, gamepad->client);
+	if (err) {
+		dev_dbg(&gamepad->client->dev, "%s: gamepad handshake failed err=%d.\n", __func__, err);
 		return err;
-
+	}
+  
 	dev_set_drvdata(&client->dev, gamepad);
 
 	return 0;
@@ -532,6 +569,7 @@ static int gip_gamepad_probe(struct gip_client *client)
 static void gip_gamepad_remove(struct gip_client *client)
 {
 	struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
+  //cancel_work_sync(&gamepad->state_work);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
 	del_timer_sync(&gamepad->rumble.timer);

--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -27,6 +27,7 @@
 
 #define GIP_GP_RUMBLE_DELAY msecs_to_jiffies(10)
 #define GIP_GP_RUMBLE_MAX 100
+#define GIP_GP_AUTH_DELAY msecs_to_jiffies(50)
 
 /* button offset from end of packet */
 #define GIP_GP_BTN_SHARE_OFFSET 18
@@ -79,7 +80,8 @@ enum gip_gamepad_motor {
 };
 
 enum gip_init_state {
-	GIP_GP_AUTHENTICATING = 0x10,
+	GIP_GP_HANDSHAKE = 0x10,
+	GIP_GP_AUTHENTICATING = 0x20,
 	GIP_GP_READY = 0xFF,
 };
 /*
@@ -145,7 +147,9 @@ struct gip_gamepad {
 	struct gip_led led;
 	struct gip_input input;
 
-  //u8 state;
+  u8 state;
+  void *auth_pkt;
+  u32 auth_pkt_sz;
 
 	bool supports_share;
 	bool supports_dli;
@@ -153,7 +157,7 @@ struct gip_gamepad {
 
 	struct gip_gamepad_rumble rumble;
 
-  //  struct work_struct state_work;
+  struct delayed_work state_work;
 };
 
 static void gip_gamepad_send_rumble(struct timer_list *timer)
@@ -304,29 +308,30 @@ static int gip_gamepad_init_input(struct gip_gamepad *gamepad)
 	input_set_abs_params(dev, ABS_HAT0X, -1, 1, 0, 0);
 	input_set_abs_params(dev, ABS_HAT0Y, -1, 1, 0, 0);
 
-	err = gip_gamepad_init_rumble(gamepad);
+/*	err = gip_gamepad_init_rumble(gamepad);
 	if (err) {
 		dev_err(&gamepad->client->dev, "%s: init rumble failed: %d\n",
 			__func__, err);
 		goto err_delete_timer;
 	}
-
+*/
 	err = input_register_device(dev);
 	if (err) {
 		dev_err(&gamepad->client->dev, "%s: register failed: %d\n",
 			__func__, err);
-		goto err_delete_timer;
+/*		goto err_delete_timer;*/
+    return err;
 	}
 
 	return 0;
-
+/*
 err_delete_timer:
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
 	del_timer_sync(&gamepad->rumble.timer);
 #else
 	timer_delete_sync(&gamepad->rumble.timer);
 #endif
-	return err;
+	return err;*/
 }
 
 static int gip_gamepad_op_battery(struct gip_client *client,
@@ -338,13 +343,12 @@ static int gip_gamepad_op_battery(struct gip_client *client,
 	gip_report_battery(&gamepad->battery, type, level);
 
   // handle pdp gamepad that need delayed authentication
-  /*
-  if (gamepad->state == GIP_GP_AUTHENTICATING)
+  if (gamepad->state == GIP_GP_HANDSHAKE)
   {
-    gamepad->state = GIP_GP_READY;
-    schedule_work(&gamepad->state_work);
-  }*/
-
+  	dev_dbg(&gamepad->client->dev, "%s: before handshake (delayed).\n", __func__);
+    schedule_delayed_work(&gamepad->state_work, GIP_GP_AUTH_DELAY);
+  }
+  
 	return 0;
 }
 
@@ -353,7 +357,15 @@ static int gip_gamepad_op_authenticate(struct gip_client *client,
 {
 	struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
 
-	return gip_auth_process_pkt(&gamepad->auth, data, len);
+	gamepad->auth_pkt = kzalloc(len, GFP_ATOMIC);
+	if (!gamepad->auth_pkt)
+		return -ENOMEM;
+
+  memcpy(gamepad->auth_pkt, data, len);
+  gamepad->auth_pkt_sz = len;
+  schedule_delayed_work(&gamepad->state_work, GIP_GP_AUTH_DELAY);
+
+  return 0;
 }
 
 static int gip_gamepad_op_guide_button(struct gip_client *client, bool down)
@@ -369,24 +381,61 @@ static int gip_gamepad_op_guide_button(struct gip_client *client, bool down)
 static int gip_gamepad_op_authenticated(struct gip_client *client)
 {
   struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
+  /*
 	int err = gip_gamepad_init_input(gamepad);
 	if (err)
 		return err;
-
+  */
+  gamepad->state = GIP_GP_READY;
+	int err = gip_gamepad_init_rumble(gamepad);
+	if (err) {
+		dev_err(&gamepad->client->dev, "%s: init rumble failed: %d\n",
+			__func__, err);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
+    del_timer_sync(&gamepad->rumble.timer);
+#else
+    timer_delete_sync(&gamepad->rumble.timer);
+#endif
+		return err;
+	}
 	return 0;
 }
 
-/*
 static void gip_gamepad_start_handshake(struct work_struct *work)
 {
-	struct gip_gamepad *gamepad = container_of(work, struct gip_gamepad, state_work);
-	int err = gip_auth_start_handshake(&gamepad->auth, gamepad->client);
-	if (err) {
-		dev_dbg(&gamepad->client->dev, "%s: gamepad handshake failed err=%d.\n", __func__, err);
-		return;
-	}
+	struct gip_gamepad *gamepad = container_of(to_delayed_work(work),
+	                                           struct gip_gamepad, state_work);
+  if(gamepad->state == GIP_GP_HANDSHAKE)
+  {
+    gamepad->state = GIP_GP_AUTHENTICATING;
+    int err = gip_auth_start_handshake(&gamepad->auth, gamepad->client);
+    if (err) {
+      dev_err(&gamepad->client->dev, "%s: gamepad handshake failed err=%d.\n", __func__, err);
+      return;
+    }
+  }
+  else if(gamepad->state == GIP_GP_AUTHENTICATING)
+  {
+    if (!gamepad->auth_pkt)
+    {
+      dev_err(&gamepad->client->dev, "%s: gamepad delayed auth msg has no buffer allocated.\n",
+              __func__);
+      return;
+    }
+
+    int err = gip_auth_process_pkt(&gamepad->auth, gamepad->auth_pkt, gamepad->auth_pkt_sz);
+    if (err)
+    {
+      dev_err(&gamepad->client->dev, "%s: gamepad auth command failed err=%d.\n", __func__, err);
+    }
+
+    kfree(gamepad->auth_pkt);
+    gamepad->auth_pkt = NULL;
+    gamepad->auth_pkt_sz = 0;
+
+    return;
+  }
 }
-*/
 
 static int gip_gamepad_op_firmware(struct gip_client *client, void *data,
 				   u32 len)
@@ -519,8 +568,8 @@ static int gip_gamepad_probe(struct gip_client *client)
 		return -ENOMEM;
 
 
-  //INIT_WORK(&gamepad->state_work, gip_gamepad_start_handshake);
-  //gamepad->state = GIP_GP_READY;//AUTHENTICATING;
+  INIT_DELAYED_WORK(&gamepad->state_work, gip_gamepad_start_handshake);
+  gamepad->state = GIP_GP_HANDSHAKE;
 
 	gamepad->client = client;
 
@@ -554,12 +603,16 @@ static int gip_gamepad_probe(struct gip_client *client)
 	if (err)
 		return err;
 
-  dev_dbg(&gamepad->client->dev, "%s: before handshake.\n", __func__);
+/*  dev_dbg(&gamepad->client->dev, "%s: before handshake.\n", __func__);
 	err = gip_auth_start_handshake(&gamepad->auth, gamepad->client);
 	if (err) {
 		dev_dbg(&gamepad->client->dev, "%s: gamepad handshake failed err=%d.\n", __func__, err);
 		return err;
-	}
+	}*/
+
+	err = gip_gamepad_init_input(gamepad);
+	if (err)
+		return err;
   
 	dev_set_drvdata(&client->dev, gamepad);
 
@@ -569,7 +622,7 @@ static int gip_gamepad_probe(struct gip_client *client)
 static void gip_gamepad_remove(struct gip_client *client)
 {
 	struct gip_gamepad *gamepad = dev_get_drvdata(&client->dev);
-  //cancel_work_sync(&gamepad->state_work);
+  cancel_delayed_work_sync(&gamepad->state_work);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
 	del_timer_sync(&gamepad->rumble.timer);

--- a/driver/headset.c
+++ b/driver/headset.c
@@ -23,6 +23,7 @@
 #define GIP_HS_MAX_RETRIES 6
 #define GIP_HS_POWER_ON_DELAY msecs_to_jiffies(250)
 #define GIP_HS_START_DELAY msecs_to_jiffies(500)
+#define GIP_HS_AUTH_DELAY msecs_to_jiffies(50)
 
 static struct gip_vidpid GIP_HS_CHECK_AUTH_IDS[] = {
 	{ 0x1532, 0x0a16 }, // Razer Thresher
@@ -57,6 +58,10 @@ struct gip_headset {
 	int start_counter;
 	bool got_initial_volume;
 	bool got_audio_packet;
+
+  void *auth_pkt;
+  u32 auth_pkt_sz;
+	struct delayed_work work_auth_delay;
 
 	struct hrtimer timer;
 	struct hrtimer start_audio_timer;
@@ -347,6 +352,31 @@ static void gip_headset_config(struct work_struct *work)
 			__func__, err);
 }
 
+static void gip_headset_op_auth_delayed(struct work_struct *work)
+{
+	struct gip_headset *headset = container_of(
+		to_delayed_work(work), typeof(*headset), work_power_on);
+	struct gip_client *client = headset->client;
+	const struct device *dev = &client->adapter->dev;
+
+  if (!headset->auth_pkt)
+  {
+    dev_err(dev, "%s: headset delayed auth msg has no buffer allocated.\n",
+            __func__);
+    return;
+  }
+
+  int err = gip_auth_process_pkt(&headset->auth, headset->auth_pkt, headset->auth_pkt_sz);
+  if (err)
+  {
+    dev_err(dev, "%s: headset auth command failed err=%d.\n", __func__, err);
+  }
+
+  kfree(headset->auth_pkt);
+  headset->auth_pkt = NULL;
+  headset->auth_pkt_sz = 0;
+}
+
 static void gip_headset_power_on(struct work_struct *work)
 {
 	struct gip_headset *headset = container_of(
@@ -455,7 +485,15 @@ static int gip_headset_op_authenticate(struct gip_client *client,
 {
 	struct gip_headset *headset = dev_get_drvdata(&client->dev);
 
-	return gip_auth_process_pkt(&headset->auth, data, len);
+	headset->auth_pkt = kzalloc(len, GFP_ATOMIC);
+	if (!headset->auth_pkt)
+		return -ENOMEM;
+
+  memcpy(headset->auth_pkt, data, len);
+  headset->auth_pkt_sz = len;
+  schedule_delayed_work(&headset->work_auth_delay, GIP_HS_AUTH_DELAY);
+
+	return 0;
 }
 
 static int gip_headset_op_authenticated(struct gip_client *client)
@@ -541,6 +579,7 @@ static int gip_headset_probe(struct gip_client *client)
 
 	INIT_WORK(&headset->work_config, gip_headset_config);
 	INIT_DELAYED_WORK(&headset->work_power_on, gip_headset_power_on);
+	INIT_DELAYED_WORK(&headset->work_auth_delay, gip_headset_op_auth_delayed);
 	INIT_WORK(&headset->work_register, gip_headset_register);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
@@ -573,6 +612,7 @@ static void gip_headset_remove(struct gip_client *client)
 
 	cancel_work_sync(&headset->work_config);
 	cancel_delayed_work_sync(&headset->work_power_on);
+	cancel_delayed_work_sync(&headset->work_auth_delay);
 	cancel_work_sync(&headset->work_register);
 	hrtimer_cancel(&headset->timer);
 	hrtimer_cancel(&headset->start_audio_timer);

--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -517,8 +517,14 @@ xone_dongle_create_client(struct xone_dongle *dongle, u8 *addr)
 static int xone_dongle_add_client(struct xone_dongle *dongle, u8 *addr)
 {
 	struct xone_dongle_client *client;
-	int err;
+	int i, err;
 	unsigned long flags;
+
+	/* reject duplicate: controller already has a WCID slot */
+	for (i = 0; i < XONE_DONGLE_MAX_CLIENTS; i++)
+		if (dongle->clients[i] &&
+		    ether_addr_equal(dongle->clients[i]->address, addr))
+			return 0;
 
 	client = xone_dongle_create_client(dongle, addr);
 	if (IS_ERR(client))

--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -889,6 +889,12 @@ static int xone_dongle_process_wlan(struct xone_dongle *dongle,
 	}
 
 	ctl = le32_to_cpu(rxwi->ctl);
+
+	/* drop frames where RXWI claims more data than the USB transfer
+	 * actually delivered — commonly the chip's own beacon loopback */
+	if (FIELD_GET(MT_RXWI_CTL_MPDU_LEN, ctl) > skb->len)
+		return 0;
+
 	skb_trim(skb, FIELD_GET(MT_RXWI_CTL_MPDU_LEN, ctl));
 
 	return xone_dongle_process_frame(dongle, skb, hdr_len,


### PR DESCRIPTION
~~This PR reintroduced a change that should have fixed the issue of stalled PDP controllers, and was proposed in https://github.com/dlundqvist/xone/pull/20 that I badly mishandled in a later merge.~~

~~delays authentication after 1st status message, otherwise my gamepad would stall the auth process when starting input and never respond as an event device.~~
~~To fix the issue, the auth process is delayed after receiving the 1st status message from the controller, which was the driver behavior as recorded in windows with usbcap.~~

**edit:** ~~the delayed auth is not necessary anymore~~, so this PR now targets the sequence pool for auth messages that shared the global pool instead of using its own unique pool as per GIP spec.

**edit:** the delayed auth is necessary after all, so it is added again. All AUTH commands are delayed to cope with strange controllers behavior ACK'ing messages as if they are fragmented when they're not.

maybe fixes https://github.com/dlundqvist/xone/issues/199
maybe fixes #42
maybe fixes #203 