### PR TITLE
patched from_timer and hrtimer_init for AlmaLinux 10 (Linux 6.12.0)

### DIFF
--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -8,6 +8,10 @@
 #include <linux/timer.h>
 #include <linux/version.h>
 
+#ifndef from_timer
+#define from_timer timer_container_of
+#endif
+
 #include "common.h"
 #include "../auth/auth.h"
 

--- a/driver/headset.c
+++ b/driver/headset.c
@@ -544,10 +544,8 @@ static int gip_headset_probe(struct gip_client *client)
 	INIT_WORK(&headset->work_register, gip_headset_register);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
-	hrtimer_init(&headset->timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
-	headset->timer.function = gip_headset_send_samples;
-	hrtimer_init(&headset->start_audio_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
-	headset->start_audio_timer.function = gip_headset_start_audio;
+	hrtimer_setup(&headset->timer, gip_headset_send_samples, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+	hrtimer_setup(&headset->start_audio_timer, gip_headset_start_audio, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
 #else
 	hrtimer_setup(&headset->timer, gip_headset_send_samples,
 		      CLOCK_MONOTONIC, HRTIMER_MODE_REL);


### PR DESCRIPTION
I noticed that this does not compile on a fresh AlmaLinux installation. Apparently it is due to some API change - but I am not sure whether it is one of the original kernel or an Alma-specific difference. Now my wireless controller works.