### PR TITLE
Fix headers install for SteamOS preview/beta kernels (e.g. -drm-exec)

### DIFF
--- a/install/steam-deck-install.sh
+++ b/install/steam-deck-install.sh
@@ -56,7 +56,8 @@ echo ""
 echo "Don't worry about \"error: command failed to execute correctly\""
 echo ""
 
-linux=$(pacman -Qsq linux-neptune | grep -e "[0-9]$" | tail -n 1)
+# Package for the running kernel (grep fallback misses variants like -drm-exec)
+linux=$(cat "/usr/lib/modules/$(uname -r)/pkgbase" 2>/dev/null || pacman -Qsq linux-neptune | grep -e "[0-9]$" | tail -n 1)
 pacman -Syu --noconfirm base-devel fakeroot glibc git \
     "$linux" "$linux-headers" linux-api-headers
 


### PR DESCRIPTION
## Problem

`install/steam-deck-install.sh` picks the kernel package with:

```sh
linux=$(pacman -Qsq linux-neptune | grep -e "[0-9]$" | tail -n 1)
```

This only matches package names ending in a digit, e.g. `linux-neptune-616`. It silently excludes suffixed variants like `linux-neptune-616-drm-exec`, which is what SteamOS installs for users on the preview/beta update channel.

For those users this always resolves to the wrong package, so headers get installed for a kernel that isn't running. DKMS then fails with:

```
Error! Your kernel headers for kernel <drm-exec version> cannot be found at
.../build or .../source.
```

## Fix

Read `/usr/lib/modules/$(uname -r)/pkgbase`, which every Arch-style kernel package writes and which names the package for the exact kernel that's currently booted. Falls back to the previous `grep` if `pkgbase` is somehow missing.

## Testing

Confirmed on an affected user's Deck: `pkgbase` for their running kernel is `linux-neptune-616-drm-exec`, and `linux-neptune-616-drm-exec-headers` exists in the repos and installs correctly - this was previously never selected.

`bash -n` and `shellcheck` pass on the modified script.