### PR TITLE
Add CI to test compilation

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "semiannually"
+    cooldown:
+      default-days: 20
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,32 @@
+name: '🧪 Test'
+
+on:
+  pull_request:
+  push:
+
+permissions: {}
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 'Build'
+    runs-on: 'ubuntu-24.04'
+    steps:
+      - name: 'Install generic kernel headers with ALSA support'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y linux-headers-generic
+
+      - name: 'Checkout'
+        uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 'Build'
+        run: |
+          KDIR="$(ls -d /usr/src/linux-headers-*-generic | sort -V | tail -n1)"
+          echo "Building against $KDIR"
+          make -C "$KDIR" M="$PWD" modules


### PR DESCRIPTION
I noticed that xone doesn't have CI. This PR introduces the following changes:

* Add CI to test compilation of the project.

  GitHub runners don't have a soundsystem, so generic kernel headers are installed and compiled against.

* Add a Dependabot config that will submit a PR every six months to update the `actions/checkout` version.

You can see [an example of a successful CI run](https://github.com/kurtmckee/pr-xone/actions/runs/30351599566) in my fork. Also, more could be done to lint and test the project, including:

* Running shellcheck to confirm that the `*.sh` scripts follow best practices
* Running clang-format to confirm that the code is formatted correctly
* Running zizmor to confirm that the GitHub workflow continues to follow best practices for security (_I ran zizmor in pedantic mode against the workflow in this PR to confirm that there are no known security issues_)

I can add more in subsequent PRs if you'd like, but this at least confirms that the code compiles when you receive PRs from contributors.

Thanks for your work on xone!